### PR TITLE
ImportMapAcresAll: update CopyTo index to 0

### DIFF
--- a/NHSE.WinForms/Subforms/Map/MapDumpHelper.cs
+++ b/NHSE.WinForms/Subforms/Map/MapDumpHelper.cs
@@ -245,7 +245,7 @@ namespace NHSE.WinForms
                 return false;
             }
 
-            modified.CopyTo(data, modified.Length);
+            modified.CopyTo(data, 0);
             return true;
         }
     }


### PR DESCRIPTION
The second parameter of [Array.CopyTo](https://docs.microsoft.com/en-us/dotnet/api/system.array.copyto?view=netcore-3.1) takes an integer that represents the index in array at which copying begins. Therefore in this case it should be set to 0 instead of the array's length.

This fixes a crash when trying to import map acres.