### PR TITLE
Fix bug causing only 3-letter .nhvh files to show in dialog

### DIFF
--- a/NHSE.WinForms/Subforms/Map/VillagerHouseEditor.cs
+++ b/NHSE.WinForms/Subforms/Map/VillagerHouseEditor.cs
@@ -94,6 +94,10 @@ namespace NHSE.WinForms
         private void B_LoadHouse_Click(object sender, EventArgs e)
         {
             var name = GetVillagerName(Houses[Index]);
+            if(name == "???")
+            {
+                name = "*";
+            }
             using var ofd = new OpenFileDialog
             {
                 Filter = "New Horizons Villager House (*.nhvh)|*.nhvh|All files (*.*)|*.*",


### PR DESCRIPTION
When trying to load a villager house into a villager whose name hasn't been populated (e.g. if you are adding a villager from scratch), the placeholder causes the dialog to look for files names "???.nhvh" which only matches 3-letter base file names.  This checks to see if the name is equal to the placeholder ???, and if so, replaces it with a * so that all .nhvh files show.