### PR TITLE
Add Bulk Move Out Functionality

### DIFF
--- a/NHSE.WinForms/Controls/VillagerEditor.Designer.cs
+++ b/NHSE.WinForms/Controls/VillagerEditor.Designer.cs
@@ -148,7 +148,7 @@
             // 
             this.B_MoveOutAllVillagers.Name = "B_MoveOutAllVillagers";
             this.B_MoveOutAllVillagers.Size = new System.Drawing.Size(185, 22);
-            this.B_MoveOutAllVillagers.Text = "Move Out All Villagers";
+            this.B_MoveOutAllVillagers.Text = "Box All Villagers";
             this.B_MoveOutAllVillagers.Click += new System.EventHandler(this.B_MoveOutAllVillagers_Click);
             // 
             // B_LoadVillager

--- a/NHSE.WinForms/Controls/VillagerEditor.Designer.cs
+++ b/NHSE.WinForms/Controls/VillagerEditor.Designer.cs
@@ -38,6 +38,7 @@
             this.B_EditVillagerRoom = new System.Windows.Forms.ToolStripMenuItem();
             this.B_EditVillagerDesign = new System.Windows.Forms.ToolStripMenuItem();
             this.B_EditVillagerPlayerMemories = new System.Windows.Forms.ToolStripMenuItem();
+            this.B_MoveOutAllVillagers = new System.Windows.Forms.ToolStripMenuItem();
             this.B_LoadVillager = new System.Windows.Forms.Button();
             this.B_DumpVillager = new System.Windows.Forms.Button();
             this.L_ExternalName = new System.Windows.Forms.Label();
@@ -101,7 +102,8 @@
             this.B_EditWear,
             this.B_EditVillagerRoom,
             this.B_EditVillagerDesign,
-            this.B_EditVillagerPlayerMemories});
+            this.B_EditVillagerPlayerMemories,
+            this.B_MoveOutAllVillagers});
             this.CM_EditVillager.Name = "CM_EditPlayer";
             this.CM_EditVillager.Size = new System.Drawing.Size(186, 114);
             // 
@@ -139,6 +141,13 @@
             this.B_EditVillagerPlayerMemories.Size = new System.Drawing.Size(185, 22);
             this.B_EditVillagerPlayerMemories.Text = "Edit Player Memories";
             this.B_EditVillagerPlayerMemories.Click += new System.EventHandler(this.B_EditVillagerPlayerMemories_Click);
+            // 
+            // B_MoveOutAllVillagers
+            // 
+            this.B_MoveOutAllVillagers.Name = "B_MoveOutAllVillagers";
+            this.B_MoveOutAllVillagers.Size = new System.Drawing.Size(185, 22);
+            this.B_MoveOutAllVillagers.Text = "Move Out All Villagers";
+            this.B_MoveOutAllVillagers.Click += new System.EventHandler(this.B_MoveOutAllVillagers_Click);
             // 
             // B_LoadVillager
             // 
@@ -372,6 +381,7 @@
         private System.Windows.Forms.ToolStripMenuItem B_EditVillagerRoom;
         private System.Windows.Forms.ToolStripMenuItem B_EditVillagerDesign;
         private System.Windows.Forms.ToolStripMenuItem B_EditVillagerPlayerMemories;
+        private System.Windows.Forms.ToolStripMenuItem B_MoveOutAllVillagers;
         private System.Windows.Forms.ToolStripMenuItem B_EditWear;
         private System.Windows.Forms.Button B_SetPhraseOriginal;
     }

--- a/NHSE.WinForms/Controls/VillagerEditor.Designer.cs
+++ b/NHSE.WinForms/Controls/VillagerEditor.Designer.cs
@@ -38,6 +38,7 @@
             this.B_EditVillagerRoom = new System.Windows.Forms.ToolStripMenuItem();
             this.B_EditVillagerDesign = new System.Windows.Forms.ToolStripMenuItem();
             this.B_EditVillagerPlayerMemories = new System.Windows.Forms.ToolStripMenuItem();
+            this.TSS_toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
             this.B_MoveOutAllVillagers = new System.Windows.Forms.ToolStripMenuItem();
             this.B_LoadVillager = new System.Windows.Forms.Button();
             this.B_DumpVillager = new System.Windows.Forms.Button();
@@ -103,6 +104,7 @@
             this.B_EditVillagerRoom,
             this.B_EditVillagerDesign,
             this.B_EditVillagerPlayerMemories,
+            this.TSS_toolStripSeparator1,
             this.B_MoveOutAllVillagers});
             this.CM_EditVillager.Name = "CM_EditPlayer";
             this.CM_EditVillager.Size = new System.Drawing.Size(186, 114);
@@ -381,6 +383,7 @@
         private System.Windows.Forms.ToolStripMenuItem B_EditVillagerRoom;
         private System.Windows.Forms.ToolStripMenuItem B_EditVillagerDesign;
         private System.Windows.Forms.ToolStripMenuItem B_EditVillagerPlayerMemories;
+        private System.Windows.Forms.ToolStripSeparator TSS_toolStripSeparator1;
         private System.Windows.Forms.ToolStripMenuItem B_MoveOutAllVillagers;
         private System.Windows.Forms.ToolStripMenuItem B_EditWear;
         private System.Windows.Forms.Button B_SetPhraseOriginal;

--- a/NHSE.WinForms/Controls/VillagerEditor.cs
+++ b/NHSE.WinForms/Controls/VillagerEditor.cs
@@ -237,6 +237,11 @@ namespace NHSE.WinForms
             { } // editor saves our changes
         }
 
+        private void B_MoveOutAllVillagers_Click(object sender, EventArgs e)
+        {
+            
+        }
+
         private void B_SetPhraseOriginal_Click(object sender, EventArgs e)
         {
             var internalName = GetCurrentVillagerInternalName();

--- a/NHSE.WinForms/Controls/VillagerEditor.cs
+++ b/NHSE.WinForms/Controls/VillagerEditor.cs
@@ -239,7 +239,13 @@ namespace NHSE.WinForms
 
         private void B_MoveOutAllVillagers_Click(object sender, EventArgs e)
         {
-            
+            var prompt = WinFormsUtil.Prompt(MessageBoxButtons.YesNo, MessageStrings.MsgMoveOutAll, MessageStrings.MsgMoveOutAllConfirm);
+            if (prompt != DialogResult.Yes)
+                return;
+            foreach (var villager in Villagers)
+                return; // to write
+            System.Media.SystemSounds.Asterisk.Play();
+            return;
         }
 
         private void B_SetPhraseOriginal_Click(object sender, EventArgs e)

--- a/NHSE.WinForms/Controls/VillagerEditor.cs
+++ b/NHSE.WinForms/Controls/VillagerEditor.cs
@@ -239,6 +239,9 @@ namespace NHSE.WinForms
 
         private void B_MoveOutAllVillagers_Click(object sender, EventArgs e)
         {
+            if (Loading)
+                return;
+
             var prompt = WinFormsUtil.Prompt(MessageBoxButtons.YesNo, MessageStrings.MsgMoveOutAll, MessageStrings.MsgMoveOutAllConfirm);
             if (prompt != DialogResult.Yes)
                 return;

--- a/NHSE.WinForms/Controls/VillagerEditor.cs
+++ b/NHSE.WinForms/Controls/VillagerEditor.cs
@@ -242,8 +242,8 @@ namespace NHSE.WinForms
             if (Loading)
                 return;
 
-            var prompt = WinFormsUtil.Prompt(MessageBoxButtons.YesNo, MessageStrings.MsgMoveOutAll, MessageStrings.MsgMoveOutAllConfirm);
-            if (prompt != DialogResult.Yes)
+            var prompt = WinFormsUtil.Prompt(MessageBoxButtons.OKCancel, MessageStrings.MsgMoveOutAll);
+            if (prompt != DialogResult.OK)
                 return;
 
             foreach (var villager in Villagers)

--- a/NHSE.WinForms/Controls/VillagerEditor.cs
+++ b/NHSE.WinForms/Controls/VillagerEditor.cs
@@ -245,8 +245,10 @@ namespace NHSE.WinForms
             var prompt = WinFormsUtil.Prompt(MessageBoxButtons.YesNo, MessageStrings.MsgMoveOutAll, MessageStrings.MsgMoveOutAllConfirm);
             if (prompt != DialogResult.Yes)
                 return;
+
             foreach (var villager in Villagers)
                 return; // to write
+
             System.Media.SystemSounds.Asterisk.Play();
             return;
         }

--- a/NHSE.WinForms/Controls/VillagerEditor.cs
+++ b/NHSE.WinForms/Controls/VillagerEditor.cs
@@ -247,7 +247,8 @@ namespace NHSE.WinForms
                 return;
 
             foreach (var villager in Villagers)
-                return; // to write
+                villager.MovingOut = true;
+            CHK_VillagerMovingOut.Checked = true;
 
             System.Media.SystemSounds.Asterisk.Play();
             return;

--- a/NHSE.WinForms/Util/MessageStrings.cs
+++ b/NHSE.WinForms/Util/MessageStrings.cs
@@ -28,6 +28,8 @@ namespace NHSE.WinForms
 
         public static string MsgMoveOut { get; set; } = "Are you trying to make the Villager move out?";
         public static string MsgMoveOutSuggest { get; set; } = "If so, set the Event Flag (024 - ForceMoveOut) to 1 so that the Villager is removed by the game.";
+        public static string MsgMoveOutAll { get; set; } = "This will put all Villagers in boxes, but will not set the ForceMoveOut flag!";
+        public static string MsgMoveOutAllConfirm { get; set; } = "Are you sure you want to do this?";
 
         public static string MsgFieldItemRemoveAsk { get; set; } = "Are you sure you want to remove {0}?";
         public static string MsgFieldItemRemoveNone { get; set; } = "Nothing removed (none found).";

--- a/NHSE.WinForms/Util/MessageStrings.cs
+++ b/NHSE.WinForms/Util/MessageStrings.cs
@@ -28,8 +28,7 @@ namespace NHSE.WinForms
 
         public static string MsgMoveOut { get; set; } = "Are you trying to make the Villager move out?";
         public static string MsgMoveOutSuggest { get; set; } = "If so, set the Event Flag (024 - ForceMoveOut) to 1 so that the Villager is removed by the game.";
-        public static string MsgMoveOutAll { get; set; } = "This will put all Villagers in boxes, but will not set the ForceMoveOut flag!";
-        public static string MsgMoveOutAllConfirm { get; set; } = "Are you sure you want to do this?";
+        public static string MsgMoveOutAll { get; set; } = "This will check the 'Moving Out' box for all Villagers.";
 
         public static string MsgFieldItemRemoveAsk { get; set; } = "Are you sure you want to remove {0}?";
         public static string MsgFieldItemRemoveNone { get; set; } = "Nothing removed (none found).";


### PR DESCRIPTION
Hi,

I frequently use NHSE to create islands full of villagers to give away.  Since the perfect villager files I have do not have the 'Moving Out' flag checked, I needed a quicker way to update the flag for all of the villagers after I loaded my next set of residents.

I did not want to make large graphical changes so was having a hard time deciding where to place the option and figured the below was best - hopefully you agree!

![image](https://user-images.githubusercontent.com/52503242/90479936-786d5400-e0fd-11ea-9ce7-0459df5f6fdc.png)

![image](https://user-images.githubusercontent.com/52503242/90479749-27f5f680-e0fd-11ea-8a68-81a9329d8549.png)
