### PR TITLE
Add Sort Items Option

### DIFF
--- a/NHSE.WinForms/Controls/ItemGridEditor.Designer.cs
+++ b/NHSE.WinForms/Controls/ItemGridEditor.Designer.cs
@@ -182,7 +182,7 @@
             this.B_Sort.Name = "B_Sort";
             this.B_Sort.Size = new System.Drawing.Size(85, 36);
             this.B_Sort.TabIndex = 8;
-            this.B_Sort.Text = "Sort...";
+            this.B_Sort.Text = "Sort";
             this.B_Sort.UseVisualStyleBackColor = true;
             this.B_Sort.Click += new System.EventHandler(this.B_Sort_Click);
             //

--- a/NHSE.WinForms/Controls/ItemGridEditor.Designer.cs
+++ b/NHSE.WinForms/Controls/ItemGridEditor.Designer.cs
@@ -177,7 +177,7 @@
             this.B_Sort.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)
             | System.Windows.Forms.AnchorStyles.Right)));
             this.B_Sort.ContextMenuStrip = this.CM_Sort;
-            this.B_Sort.Location = new System.Drawing.Point(4, 165);
+            this.B_Sort.Location = new System.Drawing.Point(4, 197);
             this.B_Sort.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.B_Sort.Name = "B_Sort";
             this.B_Sort.Size = new System.Drawing.Size(85, 36);

--- a/NHSE.WinForms/Controls/ItemGridEditor.Designer.cs
+++ b/NHSE.WinForms/Controls/ItemGridEditor.Designer.cs
@@ -297,7 +297,7 @@
             this.PAN_Navigation.Location = new System.Drawing.Point(217, 30);
             this.PAN_Navigation.Margin = new System.Windows.Forms.Padding(0);
             this.PAN_Navigation.Name = "PAN_Navigation";
-            this.PAN_Navigation.Size = new System.Drawing.Size(93, 175);
+            this.PAN_Navigation.Size = new System.Drawing.Size(93, 235);
             this.PAN_Navigation.TabIndex = 10;
             // 
             // HoverTip

--- a/NHSE.WinForms/Controls/ItemGridEditor.Designer.cs
+++ b/NHSE.WinForms/Controls/ItemGridEditor.Designer.cs
@@ -1,4 +1,4 @@
-﻿namespace NHSE.WinForms
+﻿    namespace NHSE.WinForms
 {
     partial class ItemGridEditor
     {
@@ -39,6 +39,7 @@
             this.Menu_Set = new System.Windows.Forms.ToolStripMenuItem();
             this.Menu_Delete = new System.Windows.Forms.ToolStripMenuItem();
             this.B_Clear = new System.Windows.Forms.Button();
+            this.B_Sort = new System.Windows.Forms.Button();
             this.CM_Remove = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.B_ClearAll = new System.Windows.Forms.ToolStripMenuItem();
             this.B_ClearClothing = new System.Windows.Forms.ToolStripMenuItem();
@@ -165,6 +166,20 @@
             this.B_Clear.Text = "Clear";
             this.B_Clear.UseVisualStyleBackColor = true;
             this.B_Clear.Click += new System.EventHandler(this.B_Clear_Click);
+            //
+            // B_Sort
+            //
+            this.B_Sort.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.B_Sort.ContextMenuStrip = this.CM_Sort;
+            this.B_Sort.Location = new System.Drawing.Point(4, 197);
+            this.B_Sort.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.B_Sort.Name = "B_Sort";
+            this.B_Sort.Size = new System.Drawing.Size(85, 36);
+            this.B_Sort.TabIndex = 8;
+            this.B_Sort.Text = "Sort...";
+            this.B_Sort.UseVisualStyleBackColor = true;
+            this.B_Sort.Click += new System.EventHandler(this.B_Sort_Click);
             // 
             // CM_Remove
             // 
@@ -286,6 +301,7 @@
         private System.Windows.Forms.ToolStripMenuItem Menu_Set;
         private System.Windows.Forms.ToolStripMenuItem Menu_Delete;
         private System.Windows.Forms.Button B_Clear;
+        private System.Windows.Forms.Button B_Sort;
         private System.Windows.Forms.FlowLayoutPanel FLP_Controls;
         private System.Windows.Forms.Panel PAN_Navigation;
         private System.Windows.Forms.ToolTip HoverTip;

--- a/NHSE.WinForms/Controls/ItemGridEditor.Designer.cs
+++ b/NHSE.WinForms/Controls/ItemGridEditor.Designer.cs
@@ -180,6 +180,38 @@
             this.B_Sort.Text = "Sort...";
             this.B_Sort.UseVisualStyleBackColor = true;
             this.B_Sort.Click += new System.EventHandler(this.B_Sort_Click);
+            //
+            // CM_Sort
+            //
+            this.CM_Sort.ImageScalingSize = new System.Drawing.Size(20, 20);
+            this.CM_Sort.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.B_SortAlpha,
+            this.B_SortType,
+            this.B_SortNew});
+            this.CM_Sort.Name = "CM_Sort";
+            this.CM_Sort.ShowImageMargin = false;
+            this.CM_Sort.Size = new System.Drawing.Size(186, 200);
+            //
+            // B_SortAlpha
+            //
+            this.B_SortAlpha.Name = "B_SortAlpha";
+            this.B_SortAlpha.Size = new System.Drawing.Size(185, 24);
+            this.B_SortAlpha.Text = "Alphabetical";
+            this.B_SortAlpha.Click += new System.EventHandler(this.B_SortAlpha_Click);
+            //
+            // B_SortType
+            //
+            this.B_SortType.Name = "B_SortType";
+            this.B_SortType.Size = new System.Drawing.Size(185, 24);
+            this.B_SortType.Text = "Type";
+            this.B_SortType.Click += new System.EventHandler(this.B_SortType_Click);
+            //
+            // B_SortAlpha
+            //
+            this.B_SortNew.Name = "B_SortNew";
+            this.B_SortNew.Size = new System.Drawing.Size(185, 24);
+            this.B_SortNew.Text = "New";
+            this.B_SortNew.Click += new System.EventHandler(this.B_SortNew_Click);
             // 
             // CM_Remove
             // 

--- a/NHSE.WinForms/Controls/ItemGridEditor.Designer.cs
+++ b/NHSE.WinForms/Controls/ItemGridEditor.Designer.cs
@@ -43,7 +43,6 @@
             this.CM_Sort = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.B_SortAlpha = new System.Windows.Forms.ToolStripMenuItem();
             this.B_SortType = new System.Windows.Forms.ToolStripMenuItem();
-            this.B_SortNew = new System.Windows.Forms.ToolStripMenuItem();
             this.CM_Remove = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.B_ClearAll = new System.Windows.Forms.ToolStripMenuItem();
             this.B_ClearClothing = new System.Windows.Forms.ToolStripMenuItem();
@@ -191,8 +190,7 @@
             this.CM_Sort.ImageScalingSize = new System.Drawing.Size(20, 20);
             this.CM_Sort.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.B_SortAlpha,
-            this.B_SortType,
-            this.B_SortNew});
+            this.B_SortType});
             this.CM_Sort.Name = "CM_Sort";
             this.CM_Sort.ShowImageMargin = false;
             this.CM_Sort.Size = new System.Drawing.Size(186, 200);
@@ -210,13 +208,6 @@
             this.B_SortType.Size = new System.Drawing.Size(185, 24);
             this.B_SortType.Text = "Type";
             this.B_SortType.Click += new System.EventHandler(this.B_SortType_Click);
-            //
-            // B_SortAlpha
-            //
-            this.B_SortNew.Name = "B_SortNew";
-            this.B_SortNew.Size = new System.Drawing.Size(185, 24);
-            this.B_SortNew.Text = "New";
-            this.B_SortNew.Click += new System.EventHandler(this.B_SortNew_Click);
             // 
             // CM_Remove
             // 
@@ -344,7 +335,6 @@
         private System.Windows.Forms.ContextMenuStrip CM_Sort;
         private System.Windows.Forms.ToolStripMenuItem B_SortAlpha;
         private System.Windows.Forms.ToolStripMenuItem B_SortType;
-        private System.Windows.Forms.ToolStripMenuItem B_SortNew;
         private System.Windows.Forms.FlowLayoutPanel FLP_Controls;
         private System.Windows.Forms.Panel PAN_Navigation;
         private System.Windows.Forms.ToolTip HoverTip;

--- a/NHSE.WinForms/Controls/ItemGridEditor.Designer.cs
+++ b/NHSE.WinForms/Controls/ItemGridEditor.Designer.cs
@@ -302,6 +302,10 @@
         private System.Windows.Forms.ToolStripMenuItem Menu_Delete;
         private System.Windows.Forms.Button B_Clear;
         private System.Windows.Forms.Button B_Sort;
+        private System.Windows.Forms.ContextMenuStrip CM_Sort;
+        private System.Windows.Forms.ToolStripMenuItem B_SortAlpha;
+        private System.Windows.Forms.ToolStripMenuItem B_SortType;
+        private System.Windows.Forms.ToolStripMenuItem B_SortNew;
         private System.Windows.Forms.FlowLayoutPanel FLP_Controls;
         private System.Windows.Forms.Panel PAN_Navigation;
         private System.Windows.Forms.ToolTip HoverTip;

--- a/NHSE.WinForms/Controls/ItemGridEditor.Designer.cs
+++ b/NHSE.WinForms/Controls/ItemGridEditor.Designer.cs
@@ -40,6 +40,10 @@
             this.Menu_Delete = new System.Windows.Forms.ToolStripMenuItem();
             this.B_Clear = new System.Windows.Forms.Button();
             this.B_Sort = new System.Windows.Forms.Button();
+            this.CM_Sort = new System.Windows.Forms.ContextMenuStrip(this.components);
+            this.B_SortAlpha = new System.Windows.Forms.ToolStripMenuItem();
+            this.B_SortType = new System.Windows.Forms.ToolStripMenuItem();
+            this.B_SortNew = new System.Windows.Forms.ToolStripMenuItem();
             this.CM_Remove = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.B_ClearAll = new System.Windows.Forms.ToolStripMenuItem();
             this.B_ClearClothing = new System.Windows.Forms.ToolStripMenuItem();

--- a/NHSE.WinForms/Controls/ItemGridEditor.Designer.cs
+++ b/NHSE.WinForms/Controls/ItemGridEditor.Designer.cs
@@ -56,6 +56,7 @@
             this.HoverTip = new System.Windows.Forms.ToolTip(this.components);
             this.B_ClearDive = new System.Windows.Forms.ToolStripMenuItem();
             this.CM_Hand.SuspendLayout();
+            this.CM_Sort.SuspendLayout();
             this.CM_Remove.SuspendLayout();
             this.FLP_Controls.SuspendLayout();
             this.PAN_Navigation.SuspendLayout();
@@ -176,7 +177,7 @@
             this.B_Sort.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)
             | System.Windows.Forms.AnchorStyles.Right)));
             this.B_Sort.ContextMenuStrip = this.CM_Sort;
-            this.B_Sort.Location = new System.Drawing.Point(4, 197);
+            this.B_Sort.Location = new System.Drawing.Point(4, 165);
             this.B_Sort.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.B_Sort.Name = "B_Sort";
             this.B_Sort.Size = new System.Drawing.Size(85, 36);
@@ -292,6 +293,7 @@
             this.PAN_Navigation.Controls.Add(this.L_Page);
             this.PAN_Navigation.Controls.Add(this.B_Down);
             this.PAN_Navigation.Controls.Add(this.B_Clear);
+            this.PAN_Navigation.Controls.Add(this.B_Sort);
             this.PAN_Navigation.Location = new System.Drawing.Point(217, 30);
             this.PAN_Navigation.Margin = new System.Windows.Forms.Padding(0);
             this.PAN_Navigation.Name = "PAN_Navigation";
@@ -318,6 +320,7 @@
             this.Name = "ItemGridEditor";
             this.Size = new System.Drawing.Size(321, 242);
             this.CM_Hand.ResumeLayout(false);
+            this.CM_Sort.ResumeLayout(false);
             this.CM_Remove.ResumeLayout(false);
             this.FLP_Controls.ResumeLayout(false);
             this.PAN_Navigation.ResumeLayout(false);

--- a/NHSE.WinForms/Controls/ItemGridEditor.Designer.cs
+++ b/NHSE.WinForms/Controls/ItemGridEditor.Designer.cs
@@ -248,7 +248,7 @@
             this.FLP_Controls.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.FLP_Controls.Name = "FLP_Controls";
             this.FLP_Controls.Size = new System.Drawing.Size(321, 242);
-            this.FLP_Controls.TabIndex = 8;
+            this.FLP_Controls.TabIndex = 9;
             // 
             // PAN_Navigation
             // 
@@ -260,7 +260,7 @@
             this.PAN_Navigation.Margin = new System.Windows.Forms.Padding(0);
             this.PAN_Navigation.Name = "PAN_Navigation";
             this.PAN_Navigation.Size = new System.Drawing.Size(93, 175);
-            this.PAN_Navigation.TabIndex = 9;
+            this.PAN_Navigation.TabIndex = 10;
             // 
             // HoverTip
             // 

--- a/NHSE.WinForms/Controls/ItemGridEditor.cs
+++ b/NHSE.WinForms/Controls/ItemGridEditor.cs
@@ -260,7 +260,18 @@ namespace NHSE.WinForms
 
             SetEditorItems(sortedItemsCopy);
         }
-        private void B_SortType_Click(object sender, EventArgs e) { }
+        private void B_SortType_Click(object sender, EventArgs e) {
+            IEnumerable<Item> sortedItems = Items.Where(item => item.ItemId != Item.NONE).OrderBy(item => ItemInfo.GetItemKind(item));
+            IList<Item> sortedItemsCopy = new List<Item>(); // to prevent object reference issues
+
+            foreach(Item item in sortedItems) {
+                Item itemCopy = new Item();
+                itemCopy.CopyFrom(item);
+                sortedItemsCopy.Add(itemCopy);
+            }
+
+            SetEditorItems(sortedItemsCopy);
+        }
         private void B_SortNew_Click(object sender, EventArgs e) { }
         private void SetEditorItems(IList<Item> items) {
             for (int i = 0; i < Items.Count; i++) {

--- a/NHSE.WinForms/Controls/ItemGridEditor.cs
+++ b/NHSE.WinForms/Controls/ItemGridEditor.cs
@@ -274,6 +274,9 @@ namespace NHSE.WinForms
         }
         private void B_SortNew_Click(object sender, EventArgs e) { }
         private void SetEditorItems(IList<Item> items) {
+            if (items.Count > Items.Count)
+                return;
+
             for (int i = 0; i < Items.Count; i++) {
                 if (i < items.Count) {
                     GetItem(i).CopyFrom(items[i]);

--- a/NHSE.WinForms/Controls/ItemGridEditor.cs
+++ b/NHSE.WinForms/Controls/ItemGridEditor.cs
@@ -272,7 +272,6 @@ namespace NHSE.WinForms
 
             SetEditorItems(sortedItemsCopy);
         }
-        private void B_SortNew_Click(object sender, EventArgs e) { }
         private void SetEditorItems(IList<Item> items) {
             if (items.Count > Items.Count)
                 return;

--- a/NHSE.WinForms/Controls/ItemGridEditor.cs
+++ b/NHSE.WinForms/Controls/ItemGridEditor.cs
@@ -244,6 +244,12 @@ namespace NHSE.WinForms
             System.Media.SystemSounds.Asterisk.Play();
         }
 
+        private void B_Sort_Click(object sender, EventArgs e) => ShowContextMenuBelow(CM_Sort, B_Sort);
+        private void B_SortAlpha_Click(object sender, EventArgs e) { }
+        private void B_SortType_Click(object sender, EventArgs e) { }
+        private void B_SortNew_Click(object sender, EventArgs e) { }
+
+
         private void B_ClearAll_Click(object sender, EventArgs e) => ClearItemIf(_ => true);
         private void B_ClearClothing_Click(object sender, EventArgs e) => ClearItemIf(z => ItemInfo.GetItemKind(z).IsClothing());
         private void B_ClearCrafting_Click(object sender, EventArgs e) => ClearItemIf(z => ItemInfo.GetItemKind(z).IsCrafting());

--- a/NHSE.WinForms/Controls/ItemGridEditor.cs
+++ b/NHSE.WinForms/Controls/ItemGridEditor.cs
@@ -261,7 +261,7 @@ namespace NHSE.WinForms
             SetEditorItems(sortedItemsCopy);
         }
         private void B_SortType_Click(object sender, EventArgs e) {
-            IEnumerable<Item> sortedItems = Items.Where(item => item.ItemId != Item.NONE).OrderBy(item => ItemInfo.GetItemKind(item));
+            IEnumerable<Item> sortedItems = Items.Where(item => item.ItemId != Item.NONE).OrderBy(item => GetItemText(item).ToLower()).OrderBy(item => ItemInfo.GetItemKind(item));
             IList<Item> sortedItemsCopy = new List<Item>(); // to prevent object reference issues
 
             foreach(Item item in sortedItems) {

--- a/NHSE.WinForms/Controls/ItemGridEditor.cs
+++ b/NHSE.WinForms/Controls/ItemGridEditor.cs
@@ -1,8 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Drawing;
+using System.Drawing.Text;
 using System.Linq;
 using System.Windows.Forms;
+using System.Windows.Forms.VisualStyles;
 using NHSE.Core;
 using NHSE.Sprites;
 
@@ -245,10 +248,35 @@ namespace NHSE.WinForms
         }
 
         private void B_Sort_Click(object sender, EventArgs e) => ShowContextMenuBelow(CM_Sort, B_Sort);
-        private void B_SortAlpha_Click(object sender, EventArgs e) { }
+        private void B_SortAlpha_Click(object sender, EventArgs e) {
+            IEnumerable<Item> sortedItems = Items.Where(item => item.ItemId != Item.NONE).OrderBy(item => GetItemText(item).ToLower());
+            IList<Item> sortedItemsCopy = new List<Item>(); // to prevent object reference issues
+
+            foreach(Item item in sortedItems) {
+                Item itemCopy = new Item();
+                itemCopy.CopyFrom(item);
+                sortedItemsCopy.Add(itemCopy);
+            }
+
+            SetEditorItems(sortedItemsCopy);
+        }
         private void B_SortType_Click(object sender, EventArgs e) { }
         private void B_SortNew_Click(object sender, EventArgs e) { }
+        private void SetEditorItems(IList<Item> items) {
+            for (int i = 0; i < Items.Count; i++) {
+                if (i < items.Count) {
+                    GetItem(i).CopyFrom(items[i]);
+                }
+                else {
+                    GetItem(i).CopyFrom(Item.NO_ITEM);
+                }
+                ItemUpdated();
+            }
 
+            LoadItems();
+            Editor.LoadItem(Item.NO_ITEM);
+            System.Media.SystemSounds.Asterisk.Play();
+        }
 
         private void B_ClearAll_Click(object sender, EventArgs e) => ClearItemIf(_ => true);
         private void B_ClearClothing_Click(object sender, EventArgs e) => ClearItemIf(z => ItemInfo.GetItemKind(z).IsClothing());


### PR DESCRIPTION
Hi,

This PR adds a Sort button the ItemEditorGrid that allows you to sort your inventory/storage by name (alphabetical) or by type (ItemKind).  It also adds a general SetEditorItems method used by each sorting method.

This was requested by a few other NHSE users I know to better mirror in-game sort options :)

**Screenshots:**

Sort button and context menu options:
![image](https://user-images.githubusercontent.com/52503242/91514132-01318000-e8b4-11ea-839b-2a3a4f94c477.png)

Alphabetically sorted storage:
![image](https://user-images.githubusercontent.com/52503242/91514165-160e1380-e8b4-11ea-9e91-088fb25d6db1.png)

Type sorted storage (sorts by alphabetical first):
![image](https://user-images.githubusercontent.com/52503242/91514177-1efee500-e8b4-11ea-8da0-5cf2ab2a1593.png)
