### PR TITLE
Fix bug where sort by type would only sort by alpha

### DIFF
--- a/NHSE.WinForms/Controls/ItemGridEditor.cs
+++ b/NHSE.WinForms/Controls/ItemGridEditor.cs
@@ -263,8 +263,8 @@ namespace NHSE.WinForms
         private void B_SortType_Click(object sender, EventArgs e)
         {
             var sortedItems = Items.Where(item => item.ItemId != Item.NONE)
-                .OrderBy(item => GetItemText(item).ToLower())
-                .ThenBy(ItemInfo.GetItemKind);
+                .OrderBy(item => ItemInfo.GetItemKind(item))
+                .ThenBy(item => GetItemText(item).ToLower());
             var sortedItemsCopy = new List<Item>(); // to prevent object reference issues
 
             foreach (var item in sortedItems)


### PR DESCRIPTION
Hi, it's me again!  Found there was a bug in the "sort" feature that I implemented where sorting by type would only sort by alpha, because I had the OrderBy / ThenBy swapped.  This is working correctly now.

![image](https://user-images.githubusercontent.com/52503242/93942089-b9104c80-fcfd-11ea-990a-a055d4dab475.png)
