### PR TITLE
Resolve Villager Import Bug

### DIFF
--- a/NHSE.Core/Structures/Villager/VillagerConverter.cs
+++ b/NHSE.Core/Structures/Villager/VillagerConverter.cs
@@ -24,8 +24,8 @@ namespace NHSE.Core
 
             return expect switch
             {
-                Villager1.SIZE when data.Length == Villager2.SIZE => Convert12(data),
-                Villager2.SIZE when data.Length == Villager1.SIZE => Convert21(data),
+                Villager1.SIZE when data.Length == Villager2.SIZE => Convert21(data),
+                Villager2.SIZE when data.Length == Villager1.SIZE => Convert12(data),
                 _ => data
             };
         }

--- a/NHSE.WinForms/Controls/VillagerEditor.cs
+++ b/NHSE.WinForms/Controls/VillagerEditor.cs
@@ -132,7 +132,7 @@ namespace NHSE.WinForms
             var path = ofd.FileName;
             var expectLength = SAV.Offsets.VillagerSize;
             var fi = new FileInfo(path);
-            if (VillagerConverter.IsCompatible((int)fi.Length, expectLength))
+            if (!VillagerConverter.IsCompatible((int)fi.Length, expectLength))
             {
                 WinFormsUtil.Error(string.Format(MessageStrings.MsgDataSizeMismatchImport, fi.Length, expectLength), path);
                 return;


### PR DESCRIPTION
Fixes issue #402 

Found the 2 bugs that were causing problems with the villager convertor:

* Missing not operator for VillagerConverter.IsCompatible
* Conversions from type 1->2 and 2->1 were backwards