### PR TITLE
Implement ItemsFromNHI bulk import

### DIFF
--- a/NHSE.WinForms/Subforms/Map/BulkSpawn.Designer.cs
+++ b/NHSE.WinForms/Subforms/Map/BulkSpawn.Designer.cs
@@ -40,6 +40,8 @@
             this.NUD_DIYStart = new System.Windows.Forms.NumericUpDown();
             this.L_DIYStop = new System.Windows.Forms.Label();
             this.NUD_DIYStop = new System.Windows.Forms.NumericUpDown();
+            this.L_NHI = new System.Windows.Forms.Label();
+            this.L_NHIFileName = new System.Windows.Forms.Label();
             this.CB_SpawnArrange = new System.Windows.Forms.ComboBox();
             ((System.ComponentModel.ISupportInitialize)(this.NUD_SpawnX)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.NUD_SpawnY)).BeginInit();
@@ -189,6 +191,25 @@
             0,
             0,
             0});
+            //
+            // L_NHI
+            //
+            this.L_NHI.Location = new System.Drawing.Point(14, 141);
+            this.L_NHI.Name = "L_NHI";
+            this.L_NHI.Size = new System.Drawing.Size(108, 20);
+            this.L_NHI.TabIndex = 24;
+            this.L_NHI.Text = "NHI:";
+            this.L_NHI.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            //
+            // L_NHIFileName
+            //
+            this.L_NHIFileName.Location = new System.Drawing.Point(14, 161);
+            this.L_NHIFileName.Name = "L_NHIFileName";
+            this.L_NHIFileName.Size = new System.Drawing.Size(108, 20);
+            this.L_NHIFileName.TabIndex = 25;
+            this.L_NHIFileName.Text = "<none>";
+            this.L_NHIFileName.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            this.L_NHIFileName.Click += new System.EventHandler(this.L_NHIFileName_Click);
             // 
             // CB_SpawnArrange
             // 
@@ -209,6 +230,8 @@
             this.Controls.Add(this.NUD_DIYStop);
             this.Controls.Add(this.L_DIYStart);
             this.Controls.Add(this.NUD_DIYStart);
+            this.Controls.Add(this.L_NHI);
+            this.Controls.Add(this.L_NHIFileName);
             this.Controls.Add(this.L_SpawnCount);
             this.Controls.Add(this.NUD_SpawnCount);
             this.Controls.Add(this.CB_SpawnType);
@@ -246,6 +269,8 @@
         private System.Windows.Forms.NumericUpDown NUD_DIYStart;
         private System.Windows.Forms.Label L_DIYStop;
         private System.Windows.Forms.NumericUpDown NUD_DIYStop;
+        private System.Windows.Forms.Label L_NHI;
+        private System.Windows.Forms.Label L_NHIFileName;
         private System.Windows.Forms.ComboBox CB_SpawnArrange;
     }
 }

--- a/NHSE.WinForms/Subforms/Map/BulkSpawn.cs
+++ b/NHSE.WinForms/Subforms/Map/BulkSpawn.cs
@@ -66,7 +66,7 @@ namespace NHSE.WinForms
                 var array = data.GetArray<Item>(Item.SIZE).Where(item => !item.IsNone);
                 items = Enumerable.Repeat(array, count).SelectMany(x => x);
 
-                // set flag0 = 0x20 for each item to ensure it gets placed
+                // set flag0 = 0x20 for each item to ensure it gets dropped
                 // this also forces a 2x2 item size
                 foreach (Item item in items)
                     item.SystemParam = 0x20;

--- a/NHSE.WinForms/Subforms/Map/BulkSpawn.cs
+++ b/NHSE.WinForms/Subforms/Map/BulkSpawn.cs
@@ -55,7 +55,11 @@ namespace NHSE.WinForms
             else if (type == SpawnType.ItemsFromNHI)
             {
                 if (this.NHIFilePath == "")
-                    return; // throw msg box at some point
+                {
+                    WinFormsUtil.Alert(MessageStrings.MsgFieldItemNoNHI);
+                    return;
+                }
+                    
 
                 // read non-empty slots into item array
                 var data = File.ReadAllBytes(this.NHIFilePath);

--- a/NHSE.WinForms/Util/MessageStrings.cs
+++ b/NHSE.WinForms/Util/MessageStrings.cs
@@ -37,6 +37,7 @@ namespace NHSE.WinForms
         public static string MsgFieldItemModifyNone { get; set; } = "Nothing modified (none found).";
         public static string MsgFieldItemModifyCount { get; set; } = "Modified {0} tiles on the map.";
         public static string MsgFieldItemUnsupportedLayer2Tile { get; set; } = "Unsupported Layer2 items detected.";
+        public static string MsgFieldItemNoNHI { get; set; } = "No .nhi file selected to import!";
 
         public static string MsgSysBotInfo { get; set; } = "This SysBot reads and writes RAM directly to your game when called to Read/Write.";
         public static string MsgSysBotRequired { get; set; } = "Using this functionality requires the sys-botbase sysmodule running on the console. Your console must be on the same network as the PC running this program.";


### PR DESCRIPTION
Hi,

This resolves #376 by adding an "ItemsFromNHI" option to the bulk spawner dialog.

Selecting the option will spawn a file browser dialog for the NHI file, which is displayed in the dialog.  If you hit 'Spawn' and no NHI is selected, it will throw an error.  Otherwise it will import with the selected X/Y/Count as requested

![image](https://user-images.githubusercontent.com/52503242/99603356-1c062300-29d1-11eb-8d8d-a83f8e251c0d.png)

![image](https://user-images.githubusercontent.com/52503242/99603372-23c5c780-29d1-11eb-9324-dda37bdf5481.png)

![image](https://user-images.githubusercontent.com/52503242/99603387-2c1e0280-29d1-11eb-960a-616ba9857c06.png)
