### PR TITLE
Remove duplicated item list entry

### DIFF
--- a/NHSE.Core/Structures/Item/Remake/ItemRemakeUtil.cs
+++ b/NHSE.Core/Structures/Item/Remake/ItemRemakeUtil.cs
@@ -1104,7 +1104,6 @@ namespace NHSE.Core
             {13250, 1210}, // mini circuit
             {13251, 1200}, // dinosaur toy
             {13252, 1205}, // dollhouse
-            {13352, 1157}, // 
             {13447, 1295}, // Turkey Day garden stand
             {13448, 1296}, // Turkey Day hearth
             {13449, 1293}, // Turkey Day decorations


### PR DESCRIPTION
There was a duplicated entry (spooky tower, item id 13352) in ItemRemakeUtil.List which caused an exception to be thrown. This removes the duplicate entry (the one with an empty comment)

Not sure if this was a generation error or something else.

![image](https://user-images.githubusercontent.com/52503242/99615836-241e8c80-29ea-11eb-95cb-7204e19ad577.png)
