### PR TITLE
change pattern system

### DIFF
--- a/NHSE.Core/Structures/GameFileDumper.cs
+++ b/NHSE.Core/Structures/GameFileDumper.cs
@@ -181,8 +181,8 @@ namespace NHSE.Core
         /// </summary>
         /// <param name="patterns">Patterns to load</param>
         /// <param name="path">Path to load from</param>
-        /// <param name="changeorigins">change origins of Patterns</param>
-        public static void Load(this DesignPattern[] patterns, string path, bool changeorigins)
+        /// <param name="changeOrigins">Change origins of Patterns</param>
+        public static void Load(this DesignPattern[] patterns, string path, bool changeOrigins)
         {
             if (patterns.Length == 0)
                 return;
@@ -197,7 +197,8 @@ namespace NHSE.Core
 
                 var data = File.ReadAllBytes(f);
                 var p = new DesignPattern(data);
-                if(changeorigins) p.ChangeOrigins(patterns[ctr], data);
+                if (changeOrigins)
+                    p.ChangeOrigins(patterns[ctr], data);
                 patterns[ctr] = p;
                 if (++ctr >= patterns.Length)
                     break;
@@ -237,8 +238,8 @@ namespace NHSE.Core
         /// </summary>
         /// <param name="patterns">Patterns to load</param>
         /// <param name="path">Path to load from</param>
-        /// <param name="changeorigins">change origins of Patterns</param>
-        public static void Load(this DesignPatternPRO[] patterns, string path, bool changeorigins)
+        /// <param name="changeOrigins">Change origins of Patterns</param>
+        public static void Load(this DesignPatternPRO[] patterns, string path, bool changeOrigins)
         {
             if (patterns.Length == 0)
                 return;
@@ -253,7 +254,8 @@ namespace NHSE.Core
 
                 var data = File.ReadAllBytes(f);
                 var p = new DesignPatternPRO(data);
-                if (changeorigins) p.ChangeOrigins(patterns[ctr], data);
+                if (changeOrigins)
+                    p.ChangeOrigins(patterns[ctr], data);
                 patterns[ctr] = p;
                 if (++ctr >= patterns.Length)
                     break;

--- a/NHSE.Core/Structures/GameFileDumper.cs
+++ b/NHSE.Core/Structures/GameFileDumper.cs
@@ -181,7 +181,8 @@ namespace NHSE.Core
         /// </summary>
         /// <param name="patterns">Patterns to load</param>
         /// <param name="path">Path to load from</param>
-        public static void Load(this DesignPattern[] patterns, string path)
+        /// <param name="changeorigins">change origins of Patterns</param>
+        public static void Load(this DesignPattern[] patterns, string path, bool changeorigins)
         {
             if (patterns.Length == 0)
                 return;
@@ -196,7 +197,7 @@ namespace NHSE.Core
 
                 var data = File.ReadAllBytes(f);
                 var p = new DesignPattern(data);
-                p.ChangeOrigins(patterns[ctr], data);
+                if(changeorigins) p.ChangeOrigins(patterns[ctr], data);
                 patterns[ctr] = p;
                 if (++ctr >= patterns.Length)
                     break;
@@ -236,7 +237,8 @@ namespace NHSE.Core
         /// </summary>
         /// <param name="patterns">Patterns to load</param>
         /// <param name="path">Path to load from</param>
-        public static void Load(this DesignPatternPRO[] patterns, string path)
+        /// <param name="changeorigins">change origins of Patterns</param>
+        public static void Load(this DesignPatternPRO[] patterns, string path, bool changeorigins)
         {
             if (patterns.Length == 0)
                 return;
@@ -251,7 +253,7 @@ namespace NHSE.Core
 
                 var data = File.ReadAllBytes(f);
                 var p = new DesignPatternPRO(data);
-                p.ChangeOrigins(patterns[ctr], data);
+                if (changeorigins) p.ChangeOrigins(patterns[ctr], data);
                 patterns[ctr] = p;
                 if (++ctr >= patterns.Length)
                     break;

--- a/NHSE.WinForms/Subforms/Map/PatternEditor.Designer.cs
+++ b/NHSE.WinForms/Subforms/Map/PatternEditor.Designer.cs
@@ -202,23 +202,6 @@
             this.PerformLayout();
 
         }
-        private void SetCM_DLDesign()
-        {
-            if (LB_Items.Items.Count == 0)
-            {
-                this.CM_DLDesign.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-                this.B_DumpDesign,
-                this.B_LoadDesign});
-            }
-            else
-            {
-                this.CM_DLDesign.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-                this.B_DumpDesign,
-                this.B_DumpDesignAll,
-                this.B_LoadDesign,
-                this.B_LoadDesignAll});
-            }
-        }
 
         #endregion
         private System.Windows.Forms.Button B_Save;

--- a/NHSE.WinForms/Subforms/Map/PatternEditor.Designer.cs
+++ b/NHSE.WinForms/Subforms/Map/PatternEditor.Designer.cs
@@ -34,14 +34,19 @@
             this.LB_Items = new System.Windows.Forms.ListBox();
             this.PB_Palette = new System.Windows.Forms.PictureBox();
             this.L_PatternName = new System.Windows.Forms.Label();
-            this.B_LoadDesign = new System.Windows.Forms.Button();
-            this.B_DumpDesign = new System.Windows.Forms.Button();
+            this.B_DumpLoadDesign = new System.Windows.Forms.Button();
+            this.CM_DLDesign = new System.Windows.Forms.ContextMenuStrip(this.components);
+            this.B_DumpDesign = new System.Windows.Forms.ToolStripMenuItem();
+            this.B_DumpDesignAll = new System.Windows.Forms.ToolStripMenuItem();
+            this.B_LoadDesign = new System.Windows.Forms.ToolStripMenuItem();
+            this.B_LoadDesignAll = new System.Windows.Forms.ToolStripMenuItem();
             this.PB_Pattern = new System.Windows.Forms.PictureBox();
             this.CM_Picture = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.Menu_SavePNG = new System.Windows.Forms.ToolStripMenuItem();
             ((System.ComponentModel.ISupportInitialize)(this.PB_Palette)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.PB_Pattern)).BeginInit();
             this.CM_Picture.SuspendLayout();
+            this.CM_DLDesign.SuspendLayout();
             this.SuspendLayout();
             // 
             // B_Save
@@ -96,27 +101,52 @@
             this.L_PatternName.TabIndex = 33;
             this.L_PatternName.Text = "*PatternName";
             // 
-            // B_LoadDesign
+            // B_DumpLoadDesign
             // 
-            this.B_LoadDesign.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.B_LoadDesign.Location = new System.Drawing.Point(266, 276);
-            this.B_LoadDesign.Name = "B_LoadDesign";
-            this.B_LoadDesign.Size = new System.Drawing.Size(92, 40);
-            this.B_LoadDesign.TabIndex = 32;
-            this.B_LoadDesign.Text = "Load Design";
-            this.B_LoadDesign.UseVisualStyleBackColor = true;
-            this.B_LoadDesign.Click += new System.EventHandler(this.B_LoadDesign_Click);
+            this.B_DumpLoadDesign.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.B_DumpLoadDesign.ContextMenuStrip = this.CM_DLDesign;
+            this.B_DumpLoadDesign.Location = new System.Drawing.Point(168, 276);
+            this.B_DumpLoadDesign.Name = "B_DumpLoadDesign";
+            this.B_DumpLoadDesign.Size = new System.Drawing.Size(92, 40);
+            this.B_DumpLoadDesign.TabIndex = 31;
+            this.B_DumpLoadDesign.Text = "Dump/Import";
+            this.B_DumpLoadDesign.UseVisualStyleBackColor = true;
+            this.B_DumpLoadDesign.Click += new System.EventHandler(this.B_DumpLoadDesign_Click);
+            // 
+            // CM_DLDesign
+            // 
+            this.CM_DLDesign.ImageScalingSize = new System.Drawing.Size(20, 20);
+            this.CM_DLDesign.Name = "CM_DLDesign";
+            this.CM_DLDesign.ShowImageMargin = false;
+            this.CM_DLDesign.Size = new System.Drawing.Size(93, 92);
             // 
             // B_DumpDesign
             // 
-            this.B_DumpDesign.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.B_DumpDesign.Location = new System.Drawing.Point(168, 276);
             this.B_DumpDesign.Name = "B_DumpDesign";
-            this.B_DumpDesign.Size = new System.Drawing.Size(92, 40);
-            this.B_DumpDesign.TabIndex = 31;
+            this.B_DumpDesign.Size = new System.Drawing.Size(92, 22);
             this.B_DumpDesign.Text = "Dump Design";
-            this.B_DumpDesign.UseVisualStyleBackColor = true;
             this.B_DumpDesign.Click += new System.EventHandler(this.B_DumpDesign_Click);
+            // 
+            // B_DumpDesignAll
+            // 
+            this.B_DumpDesignAll.Name = "B_DumpDesignAll";
+            this.B_DumpDesignAll.Size = new System.Drawing.Size(92, 22);
+            this.B_DumpDesignAll.Text = "Dump All Designs";
+            this.B_DumpDesignAll.Click += new System.EventHandler(this.B_DumpDesign_Click);
+            // 
+            // B_LoadDesign
+            // 
+            this.B_LoadDesign.Name = "B_LoadDesign";
+            this.B_LoadDesign.Size = new System.Drawing.Size(92, 22);
+            this.B_LoadDesign.Text = "Load Design";
+            this.B_LoadDesign.Click += new System.EventHandler(this.B_LoadDesign_Click);
+            // 
+            // B_LoadDesignAll
+            // 
+            this.B_LoadDesignAll.Name = "B_LoadDesignAll";
+            this.B_LoadDesignAll.Size = new System.Drawing.Size(92, 22);
+            this.B_LoadDesignAll.Text = "Load All Designs";
+            this.B_LoadDesignAll.Click += new System.EventHandler(this.B_LoadDesign_Click);
             // 
             // PB_Pattern
             // 
@@ -153,8 +183,7 @@
             this.ClientSize = new System.Drawing.Size(592, 328);
             this.Controls.Add(this.PB_Palette);
             this.Controls.Add(this.L_PatternName);
-            this.Controls.Add(this.B_LoadDesign);
-            this.Controls.Add(this.B_DumpDesign);
+            this.Controls.Add(this.B_DumpLoadDesign);
             this.Controls.Add(this.PB_Pattern);
             this.Controls.Add(this.LB_Items);
             this.Controls.Add(this.B_Cancel);
@@ -168,9 +197,27 @@
             ((System.ComponentModel.ISupportInitialize)(this.PB_Palette)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.PB_Pattern)).EndInit();
             this.CM_Picture.ResumeLayout(false);
+            this.CM_DLDesign.ResumeLayout(false);
             this.ResumeLayout(false);
             this.PerformLayout();
 
+        }
+        private void SetCM_DLDesign()
+        {
+            if (LB_Items.Items.Count == 0)
+            {
+                this.CM_DLDesign.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+                this.B_DumpDesign,
+                this.B_LoadDesign});
+            }
+            else
+            {
+                this.CM_DLDesign.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+                this.B_DumpDesign,
+                this.B_DumpDesignAll,
+                this.B_LoadDesign,
+                this.B_LoadDesignAll});
+            }
         }
 
         #endregion
@@ -179,8 +226,12 @@
         private System.Windows.Forms.ListBox LB_Items;
         private System.Windows.Forms.PictureBox PB_Palette;
         private System.Windows.Forms.Label L_PatternName;
-        private System.Windows.Forms.Button B_LoadDesign;
-        private System.Windows.Forms.Button B_DumpDesign;
+        private System.Windows.Forms.Button B_DumpLoadDesign;
+        private System.Windows.Forms.ContextMenuStrip CM_DLDesign;
+        private System.Windows.Forms.ToolStripMenuItem B_DumpDesign;
+        private System.Windows.Forms.ToolStripMenuItem B_DumpDesignAll;
+        private System.Windows.Forms.ToolStripMenuItem B_LoadDesign;
+        private System.Windows.Forms.ToolStripMenuItem B_LoadDesignAll;
         private System.Windows.Forms.PictureBox PB_Pattern;
         private System.Windows.Forms.ContextMenuStrip CM_Picture;
         private System.Windows.Forms.ToolStripMenuItem Menu_SavePNG;

--- a/NHSE.WinForms/Subforms/Map/PatternEditor.cs
+++ b/NHSE.WinForms/Subforms/Map/PatternEditor.cs
@@ -26,6 +26,7 @@ namespace NHSE.WinForms
                 LB_Items.Items.Add(GetPatternSummary(p));
 
             LB_Items.SelectedIndex = 0;
+            SetCM_DLDesign();
         }
 
         private void B_Cancel_Click(object sender, EventArgs e) => Close();
@@ -44,10 +45,12 @@ namespace NHSE.WinForms
         }
 
         private static string GetPatternSummary(DesignPattern p) => p.DesignName;
+        private static void ShowContextMenuBelow(ToolStripDropDown c, Control n) => c.Show(n.PointToScreen(new Point(0, n.Height)));
+        private void B_DumpLoadDesign_Click(object sender, EventArgs e) => ShowContextMenuBelow(CM_DLDesign, B_DumpLoadDesign);
 
         private void B_DumpDesign_Click(object sender, EventArgs e)
         {
-            if (ModifierKeys == Keys.Shift)
+            if ((string)((System.Windows.Forms.ToolStripMenuItem)sender).Name == "B_DumpDesignAll")
             {
                 using var fbd = new FolderBrowserDialog();
                 if (fbd.ShowDialog() != DialogResult.OK)
@@ -76,7 +79,7 @@ namespace NHSE.WinForms
 
         private void B_LoadDesign_Click(object sender, EventArgs e)
         {
-            if (ModifierKeys == Keys.Shift)
+            if ((string)((System.Windows.Forms.ToolStripMenuItem)sender).Name == "B_LoadDesignAll")
             {
                 using var fbd = new FolderBrowserDialog();
                 if (fbd.ShowDialog() != DialogResult.OK)
@@ -85,8 +88,10 @@ namespace NHSE.WinForms
                 var dir = Path.GetDirectoryName(fbd.SelectedPath);
                 if (dir == null || !Directory.Exists(dir))
                     return;
-                Patterns.Load(fbd.SelectedPath);
-                LoadPattern(Patterns[0]);
+                var result = WinFormsUtil.Prompt(MessageBoxButtons.YesNoCancel, MessageStrings.MsgAskUpdateValues);
+                Patterns.Load(fbd.SelectedPath, result == DialogResult.Yes);
+                LoadPattern(Patterns[Index]);
+                RepopulateList(Index);
                 return;
             }
 
@@ -125,6 +130,16 @@ namespace NHSE.WinForms
 
             Patterns[Index] = d;
             LoadPattern(d);
+            RepopulateList(Index);
+        }
+
+        private void RepopulateList(int index)
+        {
+            LB_Items.Items.Clear();
+            foreach (var p in Patterns)
+                LB_Items.Items.Add(GetPatternSummary(p));
+            LB_Items.SelectedIndex = index;
+            return;
         }
 
         private void LoadPattern(DesignPattern designPattern)

--- a/NHSE.WinForms/Subforms/Map/PatternEditor.cs
+++ b/NHSE.WinForms/Subforms/Map/PatternEditor.cs
@@ -29,6 +29,14 @@ namespace NHSE.WinForms
             SetCM_DLDesign();
         }
 
+        private void SetCM_DLDesign()
+        {
+            var arr = LB_Items.Items.Count == 0
+                ? new ToolStripItem[] { B_DumpDesign, B_LoadDesign }
+                : new ToolStripItem[] { B_DumpDesign, B_DumpDesignAll, B_LoadDesign, B_LoadDesignAll };
+            CM_DLDesign.Items.AddRange(arr);
+        }
+
         private void B_Cancel_Click(object sender, EventArgs e) => Close();
 
         private void B_Save_Click(object sender, EventArgs e)
@@ -50,7 +58,7 @@ namespace NHSE.WinForms
 
         private void B_DumpDesign_Click(object sender, EventArgs e)
         {
-            if ((string)((System.Windows.Forms.ToolStripMenuItem)sender).Name == "B_DumpDesignAll")
+            if (sender == B_DumpDesignAll)
             {
                 using var fbd = new FolderBrowserDialog();
                 if (fbd.ShowDialog() != DialogResult.OK)
@@ -79,7 +87,7 @@ namespace NHSE.WinForms
 
         private void B_LoadDesign_Click(object sender, EventArgs e)
         {
-            if ((string)((System.Windows.Forms.ToolStripMenuItem)sender).Name == "B_LoadDesignAll")
+            if (sender == B_LoadDesignAll)
             {
                 using var fbd = new FolderBrowserDialog();
                 if (fbd.ShowDialog() != DialogResult.OK)
@@ -139,7 +147,6 @@ namespace NHSE.WinForms
             foreach (var p in Patterns)
                 LB_Items.Items.Add(GetPatternSummary(p));
             LB_Items.SelectedIndex = index;
-            return;
         }
 
         private void LoadPattern(DesignPattern designPattern)

--- a/NHSE.WinForms/Subforms/Map/PatternEditorPRO.Designer.cs
+++ b/NHSE.WinForms/Subforms/Map/PatternEditorPRO.Designer.cs
@@ -248,24 +248,6 @@
 
         }
 
-        private void SetCM_DLDesign()
-        {
-            if (LB_Items.Items.Count == 0)
-            {
-                this.CM_DLDesign.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-                this.B_DumpDesign,
-                this.B_LoadDesign});
-            }
-            else
-            {
-                this.CM_DLDesign.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-                this.B_DumpDesign,
-                this.B_DumpDesignAll,
-                this.B_LoadDesign,
-                this.B_LoadDesignAll});
-            }
-        }
-
         #endregion
         private System.Windows.Forms.Button B_Save;
         private System.Windows.Forms.Button B_Cancel;

--- a/NHSE.WinForms/Subforms/Map/PatternEditorPRO.Designer.cs
+++ b/NHSE.WinForms/Subforms/Map/PatternEditorPRO.Designer.cs
@@ -34,8 +34,12 @@
             this.LB_Items = new System.Windows.Forms.ListBox();
             this.PB_Palette = new System.Windows.Forms.PictureBox();
             this.L_PatternName = new System.Windows.Forms.Label();
-            this.B_LoadDesign = new System.Windows.Forms.Button();
-            this.B_DumpDesign = new System.Windows.Forms.Button();
+            this.B_DumpLoadDesign = new System.Windows.Forms.Button();
+            this.CM_DLDesign = new System.Windows.Forms.ContextMenuStrip(this.components);
+            this.B_DumpDesign = new System.Windows.Forms.ToolStripMenuItem();
+            this.B_DumpDesignAll = new System.Windows.Forms.ToolStripMenuItem();
+            this.B_LoadDesign = new System.Windows.Forms.ToolStripMenuItem();
+            this.B_LoadDesignAll = new System.Windows.Forms.ToolStripMenuItem();
             this.PB_Sheet0 = new System.Windows.Forms.PictureBox();
             this.CM_Picture = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.Menu_SavePNG = new System.Windows.Forms.ToolStripMenuItem();
@@ -45,6 +49,7 @@
             ((System.ComponentModel.ISupportInitialize)(this.PB_Palette)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.PB_Sheet0)).BeginInit();
             this.CM_Picture.SuspendLayout();
+            this.CM_DLDesign.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.PB_Sheet1)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.PB_Sheet3)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.PB_Sheet2)).BeginInit();
@@ -102,27 +107,52 @@
             this.L_PatternName.TabIndex = 33;
             this.L_PatternName.Text = "*PatternName";
             // 
-            // B_LoadDesign
+            // B_DumpLoadDesign
             // 
-            this.B_LoadDesign.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.B_LoadDesign.Location = new System.Drawing.Point(266, 276);
-            this.B_LoadDesign.Name = "B_LoadDesign";
-            this.B_LoadDesign.Size = new System.Drawing.Size(92, 40);
-            this.B_LoadDesign.TabIndex = 32;
-            this.B_LoadDesign.Text = "Load Design";
-            this.B_LoadDesign.UseVisualStyleBackColor = true;
-            this.B_LoadDesign.Click += new System.EventHandler(this.B_LoadDesign_Click);
+            this.B_DumpLoadDesign.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.B_DumpLoadDesign.ContextMenuStrip = this.CM_DLDesign;
+            this.B_DumpLoadDesign.Location = new System.Drawing.Point(168, 276);
+            this.B_DumpLoadDesign.Name = "B_DumpLoadDesign";
+            this.B_DumpLoadDesign.Size = new System.Drawing.Size(92, 40);
+            this.B_DumpLoadDesign.TabIndex = 31;
+            this.B_DumpLoadDesign.Text = "Dump/Import";
+            this.B_DumpLoadDesign.UseVisualStyleBackColor = true;
+            this.B_DumpLoadDesign.Click += new System.EventHandler(this.B_DumpLoadDesign_Click);
+            // 
+            // CM_DLDesign
+            // 
+            this.CM_DLDesign.ImageScalingSize = new System.Drawing.Size(20, 20);
+            this.CM_DLDesign.Name = "CM_DLDesign";
+            this.CM_DLDesign.ShowImageMargin = false;
+            this.CM_DLDesign.Size = new System.Drawing.Size(93, 92);
             // 
             // B_DumpDesign
             // 
-            this.B_DumpDesign.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.B_DumpDesign.Location = new System.Drawing.Point(168, 276);
             this.B_DumpDesign.Name = "B_DumpDesign";
-            this.B_DumpDesign.Size = new System.Drawing.Size(92, 40);
-            this.B_DumpDesign.TabIndex = 31;
+            this.B_DumpDesign.Size = new System.Drawing.Size(92, 22);
             this.B_DumpDesign.Text = "Dump Design";
-            this.B_DumpDesign.UseVisualStyleBackColor = true;
             this.B_DumpDesign.Click += new System.EventHandler(this.B_DumpDesign_Click);
+            // 
+            // B_DumpDesignAll
+            // 
+            this.B_DumpDesignAll.Name = "B_DumpDesignAll";
+            this.B_DumpDesignAll.Size = new System.Drawing.Size(92, 22);
+            this.B_DumpDesignAll.Text = "Dump All Designs";
+            this.B_DumpDesignAll.Click += new System.EventHandler(this.B_DumpDesign_Click);
+            // 
+            // B_LoadDesign
+            // 
+            this.B_LoadDesign.Name = "B_LoadDesign";
+            this.B_LoadDesign.Size = new System.Drawing.Size(92, 22);
+            this.B_LoadDesign.Text = "Load Design";
+            this.B_LoadDesign.Click += new System.EventHandler(this.B_LoadDesign_Click);
+            // 
+            // B_LoadDesignAll
+            // 
+            this.B_LoadDesignAll.Name = "B_LoadDesignAll";
+            this.B_LoadDesignAll.Size = new System.Drawing.Size(92, 22);
+            this.B_LoadDesignAll.Text = "Load All Designs";
+            this.B_LoadDesignAll.Click += new System.EventHandler(this.B_LoadDesign_Click);
             // 
             // PB_Sheet0
             // 
@@ -195,8 +225,7 @@
             this.Controls.Add(this.PB_Sheet1);
             this.Controls.Add(this.PB_Palette);
             this.Controls.Add(this.L_PatternName);
-            this.Controls.Add(this.B_LoadDesign);
-            this.Controls.Add(this.B_DumpDesign);
+            this.Controls.Add(this.B_DumpLoadDesign);
             this.Controls.Add(this.PB_Sheet0);
             this.Controls.Add(this.LB_Items);
             this.Controls.Add(this.B_Cancel);
@@ -210,6 +239,7 @@
             ((System.ComponentModel.ISupportInitialize)(this.PB_Palette)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.PB_Sheet0)).EndInit();
             this.CM_Picture.ResumeLayout(false);
+            this.CM_DLDesign.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.PB_Sheet1)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.PB_Sheet3)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.PB_Sheet2)).EndInit();
@@ -218,14 +248,36 @@
 
         }
 
+        private void SetCM_DLDesign()
+        {
+            if (LB_Items.Items.Count == 0)
+            {
+                this.CM_DLDesign.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+                this.B_DumpDesign,
+                this.B_LoadDesign});
+            }
+            else
+            {
+                this.CM_DLDesign.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+                this.B_DumpDesign,
+                this.B_DumpDesignAll,
+                this.B_LoadDesign,
+                this.B_LoadDesignAll});
+            }
+        }
+
         #endregion
         private System.Windows.Forms.Button B_Save;
         private System.Windows.Forms.Button B_Cancel;
         private System.Windows.Forms.ListBox LB_Items;
         private System.Windows.Forms.PictureBox PB_Palette;
         private System.Windows.Forms.Label L_PatternName;
-        private System.Windows.Forms.Button B_LoadDesign;
-        private System.Windows.Forms.Button B_DumpDesign;
+        private System.Windows.Forms.Button B_DumpLoadDesign;
+        private System.Windows.Forms.ContextMenuStrip CM_DLDesign;
+        private System.Windows.Forms.ToolStripMenuItem B_DumpDesign;
+        private System.Windows.Forms.ToolStripMenuItem B_DumpDesignAll;
+        private System.Windows.Forms.ToolStripMenuItem B_LoadDesign;
+        private System.Windows.Forms.ToolStripMenuItem B_LoadDesignAll;
         private System.Windows.Forms.PictureBox PB_Sheet0;
         private System.Windows.Forms.ContextMenuStrip CM_Picture;
         private System.Windows.Forms.ToolStripMenuItem Menu_SavePNG;

--- a/NHSE.WinForms/Subforms/Map/PatternEditorPRO.cs
+++ b/NHSE.WinForms/Subforms/Map/PatternEditorPRO.cs
@@ -26,6 +26,7 @@ namespace NHSE.WinForms
                 LB_Items.Items.Add(GetPatternSummary(p));
 
             LB_Items.SelectedIndex = 0;
+            SetCM_DLDesign();
         }
 
         private void B_Cancel_Click(object sender, EventArgs e) => Close();
@@ -44,10 +45,11 @@ namespace NHSE.WinForms
         }
 
         private static string GetPatternSummary(DesignPatternPRO p) => p.DesignName;
-
+        private static void ShowContextMenuBelow(ToolStripDropDown c, Control n) => c.Show(n.PointToScreen(new Point(0, n.Height)));
+        private void B_DumpLoadDesign_Click(object sender, EventArgs e) => ShowContextMenuBelow(CM_DLDesign, B_DumpLoadDesign);
         private void B_DumpDesign_Click(object sender, EventArgs e)
         {
-            if (ModifierKeys == Keys.Shift)
+            if ((string)((System.Windows.Forms.ToolStripMenuItem)sender).Name == "B_DumpDesignAll")
             {
                 using var fbd = new FolderBrowserDialog();
                 if (fbd.ShowDialog() != DialogResult.OK)
@@ -65,7 +67,7 @@ namespace NHSE.WinForms
             using var sfd = new SaveFileDialog
             {
                 Filter = "New Horizons PRO Design (*.nhpd)|*.nhpd|All files (*.*)|*.*",
-                FileName = $"{name}.nhd",
+                FileName = $"{name}.nhpd",
             };
             if (sfd.ShowDialog() != DialogResult.OK)
                 return;
@@ -76,7 +78,7 @@ namespace NHSE.WinForms
 
         private void B_LoadDesign_Click(object sender, EventArgs e)
         {
-            if (ModifierKeys == Keys.Shift)
+            if ((string)((System.Windows.Forms.ToolStripMenuItem)sender).Name == "B_LoadDesignAll")
             {
                 using var fbd = new FolderBrowserDialog();
                 if (fbd.ShowDialog() != DialogResult.OK)
@@ -85,8 +87,10 @@ namespace NHSE.WinForms
                 var dir = Path.GetDirectoryName(fbd.SelectedPath);
                 if (dir == null || !Directory.Exists(dir))
                     return;
-                Patterns.Load(fbd.SelectedPath);
-                LoadPattern(Patterns[0]);
+                var result = WinFormsUtil.Prompt(MessageBoxButtons.YesNoCancel, MessageStrings.MsgAskUpdateValues);
+                Patterns.Load(fbd.SelectedPath, result == DialogResult.Yes);
+                LoadPattern(Patterns[Index]);
+                RepopulateList(Index);
                 return;
             }
 
@@ -95,7 +99,7 @@ namespace NHSE.WinForms
             using var ofd = new OpenFileDialog
             {
                 Filter = "New Horizons PRO Design (*.nhpd)|*.nhpd|All files (*.*)|*.*",
-                FileName = $"{name}.nhd",
+                FileName = $"{name}.nhpd",
             };
             if (ofd.ShowDialog() != DialogResult.OK)
                 return;
@@ -125,6 +129,16 @@ namespace NHSE.WinForms
 
             Patterns[Index] = d;
             LoadPattern(d);
+            RepopulateList(Index);
+        }
+
+        private void RepopulateList(int index)
+        {
+            LB_Items.Items.Clear();
+            foreach (var p in Patterns)
+                LB_Items.Items.Add(GetPatternSummary(p));
+            LB_Items.SelectedIndex = index;
+            return;
         }
 
         private void LoadPattern(DesignPatternPRO dp)

--- a/NHSE.WinForms/Subforms/Map/PatternEditorPRO.cs
+++ b/NHSE.WinForms/Subforms/Map/PatternEditorPRO.cs
@@ -29,6 +29,14 @@ namespace NHSE.WinForms
             SetCM_DLDesign();
         }
 
+        private void SetCM_DLDesign()
+        {
+            var arr = LB_Items.Items.Count == 0
+                ? new ToolStripItem[] { B_DumpDesign, B_LoadDesign }
+                : new ToolStripItem[] { B_DumpDesign, B_DumpDesignAll, B_LoadDesign, B_LoadDesignAll };
+            CM_DLDesign.Items.AddRange(arr);
+        }
+
         private void B_Cancel_Click(object sender, EventArgs e) => Close();
 
         private void B_Save_Click(object sender, EventArgs e)
@@ -49,7 +57,7 @@ namespace NHSE.WinForms
         private void B_DumpLoadDesign_Click(object sender, EventArgs e) => ShowContextMenuBelow(CM_DLDesign, B_DumpLoadDesign);
         private void B_DumpDesign_Click(object sender, EventArgs e)
         {
-            if ((string)((System.Windows.Forms.ToolStripMenuItem)sender).Name == "B_DumpDesignAll")
+            if (sender == B_DumpDesignAll)
             {
                 using var fbd = new FolderBrowserDialog();
                 if (fbd.ShowDialog() != DialogResult.OK)
@@ -78,7 +86,7 @@ namespace NHSE.WinForms
 
         private void B_LoadDesign_Click(object sender, EventArgs e)
         {
-            if ((string)((System.Windows.Forms.ToolStripMenuItem)sender).Name == "B_LoadDesignAll")
+            if (sender == B_LoadDesignAll)
             {
                 using var fbd = new FolderBrowserDialog();
                 if (fbd.ShowDialog() != DialogResult.OK)
@@ -138,7 +146,6 @@ namespace NHSE.WinForms
             foreach (var p in Patterns)
                 LB_Items.Items.Add(GetPatternSummary(p));
             LB_Items.SelectedIndex = index;
-            return;
         }
 
         private void LoadPattern(DesignPatternPRO dp)


### PR DESCRIPTION
To make dumping/loading designs match other dumping/loading buttons (terrain, acre and so on)
+ clicking on "Dump/Load Design" will draw a context menu with 4 options (2 if it's only one design pattern e.g. town flag).
+ when loading designs, I made the Listbox with the design names repopulate (update names) and select the user-selected design instead of going to index = 0;
+ when loading all designs I open a prompt to update "values" or not, instead of by default updating them.
+ fixed file name of dumped singular pro designs to .nhpd instead of .nhd lol