### PR TITLE
Villager PRO Design owner overwrite + bug fix for placed design path compliance

### DIFF
--- a/NHSE.Core/Save/Offsets/MainSaveOffsets.cs
+++ b/NHSE.Core/Save/Offsets/MainSaveOffsets.cs
@@ -116,7 +116,7 @@ namespace NHSE.Core
                 throw new ArgumentOutOfRangeException(nameof(index));
             playerID.CopyTo(p.Data, 0x54); // overwrite playerID bytes so player owns
             townID.CopyTo(p.Data, 0x38); // overwrite townID bytes so player owns
-            byte[] wipeflag = new byte[] { 0x00, 0x00, 0x00, 0x00 }; // wipe so player owns
+            byte[] wipeflag = new byte[] { 0x02, 0xEE, 0x00, 0x00 }; // wipe so player owns
             wipeflag.CopyTo(p.Data, 0x70);
             p.Data.CopyTo(data, LandMyDesign + (index * DesignPattern.SIZE));
             byte[] editedflag = new byte[] { 0x00 };

--- a/NHSE.WinForms/Editor.cs
+++ b/NHSE.WinForms/Editor.cs
@@ -166,7 +166,7 @@ namespace NHSE.WinForms
         {
             var p0 = SAV.Players[0].Personal;
             var villagers = SAV.Main.GetVillagers();
-            var v = new VillagerEditor(villagers, p0, SAV.Main, true) {Dock = DockStyle.Fill};
+            var v = new VillagerEditor(villagers, p0, SAV, true) {Dock = DockStyle.Fill};
             Tab_Villagers.Controls.Add(v);
             return v;
         }


### PR DESCRIPTION
1. Added fix for placed transparent designs that weren't complying to path contouring
(refer issue: https://github.com/kwsch/NHSE/issues/641).
Offset ``0x70 -> 0x71`` in pattern data block needs to be set to ``0x02, 0xEE`` to maintain the patterns ability to comply to pathing/terrain placed underneath if the design pattern is transparent.

2. Shifted HorizonSave into VillagerEditor in place of MainSave and adjusted accordingly to give VillagerEditor better access to save file offsets etc. and added overwrite for Villager PRO patterns to set imported ones to be made/owned by the player for consistency (town and player ID bytes).