### PR TITLE
Added simple copy to clipboard to help dump nice flags

### DIFF
--- a/NHSE.WinForms/Subforms/Map/MiscDumpHelper.cs
+++ b/NHSE.WinForms/Subforms/Map/MiscDumpHelper.cs
@@ -231,6 +231,10 @@ namespace NHSE.WinForms
             if (sfd.ShowDialog() == DialogResult.OK)
                 File.WriteAllBytes(sfd.FileName, data);
         }
+        public static void DumpFlagsToClipboard(string data)
+        {
+            Clipboard.SetData(DataFormats.Text, data);
+        }
 
         public static byte[] LoadFlags(int size, string name)
         {

--- a/NHSE.WinForms/Subforms/Player/FlagEditor.Designer.cs
+++ b/NHSE.WinForms/Subforms/Player/FlagEditor.Designer.cs
@@ -35,6 +35,7 @@
             this.L_Count = new System.Windows.Forms.Label();
             this.B_Load = new System.Windows.Forms.Button();
             this.B_Dump = new System.Windows.Forms.Button();
+            this.B_Copy = new System.Windows.Forms.Button();
             ((System.ComponentModel.ISupportInitialize)(this.NUD_Count)).BeginInit();
             this.SuspendLayout();
             // 
@@ -123,11 +124,23 @@
             this.B_Dump.UseVisualStyleBackColor = true;
             this.B_Dump.Click += new System.EventHandler(this.B_Dump_Click);
             // 
+            // B_Copy
+            // 
+            this.B_Copy.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.B_Copy.Location = new System.Drawing.Point(200, 100);
+            this.B_Copy.Name = "B_Copy";
+            this.B_Copy.Size = new System.Drawing.Size(72, 23);
+            this.B_Copy.TabIndex = 10;
+            this.B_Copy.Text = "Copy";
+            this.B_Copy.UseVisualStyleBackColor = true;
+            this.B_Copy.Click += new System.EventHandler(this.B_Copy_Click);
+            // 
             // FlagEditor
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(284, 261);
+            this.Controls.Add(this.B_Copy);
             this.Controls.Add(this.B_Load);
             this.Controls.Add(this.B_Dump);
             this.Controls.Add(this.L_Count);
@@ -156,5 +169,6 @@
         private System.Windows.Forms.Label L_Count;
         private System.Windows.Forms.Button B_Load;
         private System.Windows.Forms.Button B_Dump;
+        private System.Windows.Forms.Button B_Copy;
     }
 }

--- a/NHSE.WinForms/Subforms/Player/FlagEditor.cs
+++ b/NHSE.WinForms/Subforms/Player/FlagEditor.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Text;
 using System.Windows.Forms;
 using NHSE.Core;
 
@@ -60,6 +61,17 @@ namespace NHSE.WinForms
             if (data.Length != 0)
                 Buffer.BlockCopy(data, 0, Counts, 0, data.Length);
             LB_Counts.SelectedIndex = LB_Counts.SelectedIndex;
+        }
+
+        private void B_Copy_Click(object sender, EventArgs e)
+        {
+            var exportBuffer = new StringBuilder();
+
+            var str = GameInfo.Strings.InternalNameTranslation;
+            for (ushort i = 0; i < Counts.Length; i++)
+                exportBuffer.AppendLine(EventFlagPlayer.GetName(i, Counts[i], str));
+
+            MiscDumpHelper.DumpFlagsToClipboard(exportBuffer.ToString());
         }
     }
 }


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**
When comparing flags from a save externally in a compare tool, it can help to have the nice names visible to help with the comparison.

**Describe the solution you'd like**
A button to copy the nice flags to clipboard.