### PR TITLE
Add Campsite Editor

### DIFF
--- a/NHSE.Core/Save/Files/MainSave.cs
+++ b/NHSE.Core/Save/Files/MainSave.cs
@@ -15,11 +15,19 @@ public sealed class MainSave : EncryptedFilePair
 
     public Hemisphere Hemisphere { get => (Hemisphere)Data[Offsets.WeatherArea]; set => Data[Offsets.WeatherArea] = (byte)value; }
     public AirportColor AirportThemeColor { get => (AirportColor)Data[Offsets.AirportThemeColor]; set => Data[Offsets.AirportThemeColor] = (byte)value; }
-
     public uint WeatherSeed
     {
         get => ReadUInt32LittleEndian(Data[Offsets.WeatherRandSeed..]);
         set => WriteUInt32LittleEndian(Data[Offsets.WeatherRandSeed..], value);
+    }
+
+    public byte CampsiteStatus { get => Data[Offsets.GSaveCampSite]; set => Data[Offsets.GSaveCampSite] = value; }
+    public byte CampsiteVillagerVariantID { get => Data[Offsets.GSaveNpcCamp]; set => Data[Offsets.GSaveNpcCamp] = value; }
+    public byte CampsiteVillagerSpeciesID { get => Data[Offsets.GSaveNpcCamp+1]; set => Data[Offsets.GSaveNpcCamp+1] = value; }
+    public GSaveDate CampTimestamp
+    {
+        get => Data.ToStructure<GSaveDate>(Offsets.CampLastVisitTime, GSaveDate.SIZE);
+        set => value.ToBytes().CopyTo(Data[Offsets.CampLastVisitTime..]);
     }
 
     public IVillager GetVillager(int index) => Offsets.ReadVillager(Data, index);
@@ -260,29 +268,6 @@ public sealed class MainSave : EncryptedFilePair
     {
         get => Data.Slice(Offsets.FruitFlags, 5);
         set => value.ToArray().CopyTo(Data[Offsets.FruitFlags..]);
-    }
-    public void UpdateFruitFlags()
-    {
-        var fruit = new byte[] { 00, 00, 00, 00, 00 };
-        switch (SpecialtyFruit)
-        {
-            case 2213: // Apple
-                fruit[0] = 01;
-                break;
-            case 2287: // Cherry
-                fruit[4] = 01;
-                break;
-            case 2214: // Orange
-                fruit[1] = 01;
-                break;
-            case 2286: // Peach
-                fruit[3] = 01;
-                break;
-            case 2285: // Pear
-                fruit[2] = 01;
-                break;
-        }
-        FruitFlags = fruit;
     }
 
     public GSaveTime LastSaved => Data.Slice(Offsets.LastSavedTime, GSaveTime.SIZE).ToStructure<GSaveTime>();

--- a/NHSE.Core/Save/Offsets/MainSaveOffsets.cs
+++ b/NHSE.Core/Save/Offsets/MainSaveOffsets.cs
@@ -50,6 +50,9 @@ public abstract class MainSaveOffsets
     public abstract int SpecialtyFlower { get; }
     public abstract int BulletinBoard { get; }
     public abstract int AirportThemeColor { get; }
+    public abstract int GSaveCampSite { get; }
+    public abstract int GSaveNpcCamp {  get; }
+    public abstract int CampLastVisitTime { get; }
 
     public abstract int LostItemBox { get; }
     public abstract int LastSavedTime { get; }

--- a/NHSE.Core/Save/Offsets/MainSaveOffsets10.cs
+++ b/NHSE.Core/Save/Offsets/MainSaveOffsets10.cs
@@ -49,6 +49,9 @@ public class MainSaveOffsets10 : MainSaveOffsets
     public override int SpecialtyFlower => SisterFlower + 1;
     public override int BulletinBoard => GSaveLandStart + 0x4159F8;
     public override int AirportThemeColor => GSaveLandStart + 0x4F6600;
+    public override int GSaveCampSite => GSaveLandStart + 0x4f64e8;
+    public override int GSaveNpcCamp => GSaveCampSite + 4;
+    public override int CampLastVisitTime => GSaveCampSite + 0x110;
     #endregion
 
     #region GSaveLandOther

--- a/NHSE.Core/Save/Offsets/MainSaveOffsets11.cs
+++ b/NHSE.Core/Save/Offsets/MainSaveOffsets11.cs
@@ -49,6 +49,9 @@ public class MainSaveOffsets11 : MainSaveOffsets
     public override int SpecialtyFlower => SisterFlower + 1;
     public override int BulletinBoard => GSaveLandStart + 0x416190;
     public override int AirportThemeColor => GSaveLandStart + 0x4F6D98;
+    public override int GSaveCampSite => GSaveLandStart + 0x4f6c80;
+    public override int GSaveNpcCamp => GSaveCampSite + 4;
+    public override int CampLastVisitTime => GSaveCampSite + 0x110;
     #endregion
 
     #region GSaveLandOther

--- a/NHSE.Core/Save/Offsets/MainSaveOffsets110.cs
+++ b/NHSE.Core/Save/Offsets/MainSaveOffsets110.cs
@@ -51,6 +51,9 @@ public class MainSaveOffsets110 : MainSaveOffsets
     public override int SpecialtyFlower => SisterFlower + 1;
     public override int BulletinBoard => GSaveLandStart + 0x443158;
     public override int AirportThemeColor => GSaveLandStart + 0x523d60;
+    public override int GSaveCampSite => GSaveLandStart + 0x523c48;
+    public override int GSaveNpcCamp => GSaveCampSite + 4;
+    public override int CampLastVisitTime => GSaveCampSite + 0x110;
     #endregion
 
     #region GSaveLandOther

--- a/NHSE.Core/Save/Offsets/MainSaveOffsets111.cs
+++ b/NHSE.Core/Save/Offsets/MainSaveOffsets111.cs
@@ -52,6 +52,9 @@ public class MainSaveOffsets111 : MainSaveOffsets
     public override int SpecialtyFlower => SisterFlower + 1;
     public override int BulletinBoard => GSaveLandStart + 0x443158;
     public override int AirportThemeColor => GSaveLandStart + 0x523d60;
+    public override int GSaveCampSite => GSaveLandStart + 0x523c48;
+    public override int GSaveNpcCamp => GSaveCampSite + 4;
+    public override int CampLastVisitTime => GSaveCampSite + 0x110;
     #endregion
 
     #region GSaveLandOther

--- a/NHSE.Core/Save/Offsets/MainSaveOffsets12.cs
+++ b/NHSE.Core/Save/Offsets/MainSaveOffsets12.cs
@@ -49,6 +49,9 @@ public class MainSaveOffsets12 : MainSaveOffsets
     public override int SpecialtyFlower => SisterFlower + 1;
     public override int BulletinBoard => GSaveLandStart + 0x416440;
     public override int AirportThemeColor => GSaveLandStart + 0x4F7048;
+    public override int GSaveCampSite => GSaveLandStart + 0x4f6c80;
+    public override int GSaveNpcCamp => GSaveCampSite + 4;
+    public override int CampLastVisitTime => GSaveCampSite + 0x110;
     #endregion
 
     #region GSaveLandOther

--- a/NHSE.Core/Save/Offsets/MainSaveOffsets13.cs
+++ b/NHSE.Core/Save/Offsets/MainSaveOffsets13.cs
@@ -49,6 +49,9 @@ public class MainSaveOffsets13 : MainSaveOffsets
     public override int SpecialtyFlower => SisterFlower + 1;
     public override int BulletinBoard => GSaveLandStart + 0x416440;
     public override int AirportThemeColor => GSaveLandStart + 0x4F7048;
+    public override int GSaveCampSite => GSaveLandStart + 0x4f6c80;
+    public override int GSaveNpcCamp => GSaveCampSite + 4;
+    public override int CampLastVisitTime => GSaveCampSite + 0x110;
     #endregion
 
     #region GSaveLandOther

--- a/NHSE.Core/Save/Offsets/MainSaveOffsets14.cs
+++ b/NHSE.Core/Save/Offsets/MainSaveOffsets14.cs
@@ -49,6 +49,9 @@ public class MainSaveOffsets14 : MainSaveOffsets
     public override int SpecialtyFlower => SisterFlower + 1;
     public override int BulletinBoard => GSaveLandStart + 0x416440;
     public override int AirportThemeColor => GSaveLandStart + 0x4F7048;
+    public override int GSaveCampSite => GSaveLandStart + 0x4f6c80;
+    public override int GSaveNpcCamp => GSaveCampSite + 4;
+    public override int CampLastVisitTime => GSaveCampSite + 0x110;
     #endregion
 
     #region GSaveLandOther

--- a/NHSE.Core/Save/Offsets/MainSaveOffsets15.cs
+++ b/NHSE.Core/Save/Offsets/MainSaveOffsets15.cs
@@ -49,6 +49,9 @@ public class MainSaveOffsets15 : MainSaveOffsets
     public override int SpecialtyFlower => SisterFlower + 1;
     public override int BulletinBoard => GSaveLandStart + 0x421880;
     public override int AirportThemeColor => GSaveLandStart + 0x502488;
+    public override int GSaveCampSite => GSaveLandStart + 0x502370;
+    public override int GSaveNpcCamp => GSaveCampSite + 4;
+    public override int CampLastVisitTime => GSaveCampSite + 0x110;
     #endregion
 
     #region GSaveLandOther

--- a/NHSE.Core/Save/Offsets/MainSaveOffsets16.cs
+++ b/NHSE.Core/Save/Offsets/MainSaveOffsets16.cs
@@ -49,6 +49,9 @@ public class MainSaveOffsets16 : MainSaveOffsets
     public override int SpecialtyFlower => SisterFlower + 1;
     public override int BulletinBoard => GSaveLandStart + 0x421950;
     public override int AirportThemeColor => GSaveLandStart + 0x502558;
+    public override int GSaveCampSite => GSaveLandStart + 0x502370;
+    public override int GSaveNpcCamp => GSaveCampSite + 4;
+    public override int CampLastVisitTime => GSaveCampSite + 0x110;
     #endregion
 
     #region GSaveLandOther

--- a/NHSE.Core/Save/Offsets/MainSaveOffsets17.cs
+++ b/NHSE.Core/Save/Offsets/MainSaveOffsets17.cs
@@ -49,6 +49,9 @@ public class MainSaveOffsets17 : MainSaveOffsets
     public override int SpecialtyFlower => SisterFlower + 1;
     public override int BulletinBoard => GSaveLandStart + 0x41fb18;
     public override int AirportThemeColor => GSaveLandStart + 0x500720;
+    public override int GSaveCampSite => GSaveLandStart + 0x500608;
+    public override int GSaveNpcCamp => GSaveCampSite + 4;
+    public override int CampLastVisitTime => GSaveCampSite + 0x110;
     #endregion
 
     #region GSaveLandOther

--- a/NHSE.Core/Save/Offsets/MainSaveOffsets18.cs
+++ b/NHSE.Core/Save/Offsets/MainSaveOffsets18.cs
@@ -50,6 +50,9 @@ public class MainSaveOffsets18 : MainSaveOffsets
     public override int SpecialtyFlower => SisterFlower + 1;
     public override int BulletinBoard => GSaveLandStart + 0x41fb18;
     public override int AirportThemeColor => GSaveLandStart + 0x500720;
+    public override int GSaveCampSite => GSaveLandStart + 0x500608;
+    public override int GSaveNpcCamp => GSaveCampSite + 4;
+    public override int CampLastVisitTime => GSaveCampSite + 0x110;
     #endregion
 
     #region GSaveLandOther

--- a/NHSE.Core/Save/Offsets/MainSaveOffsets19.cs
+++ b/NHSE.Core/Save/Offsets/MainSaveOffsets19.cs
@@ -51,6 +51,9 @@ public class MainSaveOffsets19 : MainSaveOffsets
     public override int SpecialtyFlower => SisterFlower + 1;
     public override int BulletinBoard => GSaveLandStart + 0x443148;
     public override int AirportThemeColor => GSaveLandStart + 0x523d50;
+    public override int GSaveCampSite => GSaveLandStart + 0x523c38;
+    public override int GSaveNpcCamp => GSaveCampSite + 4;
+    public override int CampLastVisitTime => GSaveCampSite + 0x110;
     #endregion
 
     #region GSaveLandOther

--- a/NHSE.Core/Save/Offsets/MainSaveOffsets20.cs
+++ b/NHSE.Core/Save/Offsets/MainSaveOffsets20.cs
@@ -52,6 +52,9 @@ public class MainSaveOffsets20 : MainSaveOffsets
     public override int SpecialtyFlower => SisterFlower + 1;
     public override int BulletinBoard => GSaveLandStart + 0x462bc0;
     public override int AirportThemeColor => GSaveLandStart + 0x5437c8;
+    public override int GSaveCampSite => GSaveLandStart + 0x5436b0;
+    public override int GSaveNpcCamp => GSaveCampSite + 4;
+    public override int CampLastVisitTime => GSaveCampSite + 0x110;
     #endregion
 
     #region GSaveLandOther

--- a/NHSE.Core/Save/Offsets/MainSaveOffsets30.cs
+++ b/NHSE.Core/Save/Offsets/MainSaveOffsets30.cs
@@ -72,6 +72,9 @@ public class MainSaveOffsets30 : MainSaveOffsets
     // GSaveBulletinBoard
     public override int BulletinBoard => GSaveLandStart + 0x4950a8;
     public override int AirportThemeColor => GSaveLandStart + 0x575cb0;
+    public override int GSaveCampSite => GSaveLandStart + 0x575B98;
+    public override int GSaveNpcCamp => GSaveCampSite + 4;
+    public override int CampLastVisitTime => GSaveCampSite + 0x110;
     #endregion
 
     #region GSaveLandOther

--- a/NHSE.WinForms/Editor.Designer.cs
+++ b/NHSE.WinForms/Editor.Designer.cs
@@ -45,6 +45,7 @@
             CM_Picture = new System.Windows.Forms.ContextMenuStrip(components);
             Menu_SavePNG = new System.Windows.Forms.ToolStripMenuItem();
             Tab_Map = new System.Windows.Forms.TabPage();
+            B_EditCampsite = new System.Windows.Forms.Button();
             NUD_WeatherSeed = new System.Windows.Forms.NumericUpDown();
             L_WeatherSeed = new System.Windows.Forms.Label();
             B_EditDesignsTailor = new System.Windows.Forms.Button();
@@ -68,6 +69,8 @@
             B_RecycleBin = new System.Windows.Forms.Button();
             Tab_Villagers = new System.Windows.Forms.TabPage();
             Tab_Players = new System.Windows.Forms.TabPage();
+            L_HotelTickets = new System.Windows.Forms.Label();
+            NUD_HotelTickets = new System.Windows.Forms.NumericUpDown();
             L_Poki = new System.Windows.Forms.Label();
             NUD_Poki = new System.Windows.Forms.NumericUpDown();
             L_EarnedMiles = new System.Windows.Forms.Label();
@@ -101,14 +104,13 @@
             CB_Players = new System.Windows.Forms.ComboBox();
             PB_Player = new System.Windows.Forms.PictureBox();
             TC_Editors = new System.Windows.Forms.TabControl();
-            L_HotelTickets = new System.Windows.Forms.Label();
-            NUD_HotelTickets = new System.Windows.Forms.NumericUpDown();
             Menu_Editor.SuspendLayout();
             CM_Picture.SuspendLayout();
             Tab_Map.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)NUD_WeatherSeed).BeginInit();
             CM_EditMap.SuspendLayout();
             Tab_Players.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)NUD_HotelTickets).BeginInit();
             ((System.ComponentModel.ISupportInitialize)NUD_Poki).BeginInit();
             ((System.ComponentModel.ISupportInitialize)NUD_TotalNookMiles).BeginInit();
             ((System.ComponentModel.ISupportInitialize)NUD_StorageCount).BeginInit();
@@ -120,7 +122,6 @@
             ((System.ComponentModel.ISupportInitialize)NUD_BankBells).BeginInit();
             ((System.ComponentModel.ISupportInitialize)PB_Player).BeginInit();
             TC_Editors.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)NUD_HotelTickets).BeginInit();
             SuspendLayout();
             // 
             // Menu_Editor
@@ -237,6 +238,7 @@
             // 
             // Tab_Map
             // 
+            Tab_Map.Controls.Add(B_EditCampsite);
             Tab_Map.Controls.Add(NUD_WeatherSeed);
             Tab_Map.Controls.Add(L_WeatherSeed);
             Tab_Map.Controls.Add(B_EditDesignsTailor);
@@ -259,6 +261,17 @@
             Tab_Map.TabIndex = 2;
             Tab_Map.Text = "Map";
             Tab_Map.UseVisualStyleBackColor = true;
+            // 
+            // B_EditCampsite
+            // 
+            B_EditCampsite.Location = new System.Drawing.Point(121, 195);
+            B_EditCampsite.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            B_EditCampsite.Name = "B_EditCampsite";
+            B_EditCampsite.Size = new System.Drawing.Size(107, 46);
+            B_EditCampsite.TabIndex = 66;
+            B_EditCampsite.Text = "Edit Campsite";
+            B_EditCampsite.UseVisualStyleBackColor = true;
+            B_EditCampsite.Click += B_EditCampsite_Click;
             // 
             // NUD_WeatherSeed
             // 
@@ -507,6 +520,25 @@
             Tab_Players.TabIndex = 1;
             Tab_Players.Text = "Players";
             Tab_Players.UseVisualStyleBackColor = true;
+            // 
+            // L_HotelTickets
+            // 
+            L_HotelTickets.Location = new System.Drawing.Point(166, 273);
+            L_HotelTickets.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            L_HotelTickets.Name = "L_HotelTickets";
+            L_HotelTickets.Size = new System.Drawing.Size(98, 23);
+            L_HotelTickets.TabIndex = 30;
+            L_HotelTickets.Text = "Hotel Tickets:";
+            L_HotelTickets.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+            // 
+            // NUD_HotelTickets
+            // 
+            NUD_HotelTickets.Location = new System.Drawing.Point(271, 273);
+            NUD_HotelTickets.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            NUD_HotelTickets.Maximum = new decimal(new int[] { int.MaxValue, 0, 0, 0 });
+            NUD_HotelTickets.Name = "NUD_HotelTickets";
+            NUD_HotelTickets.Size = new System.Drawing.Size(117, 23);
+            NUD_HotelTickets.TabIndex = 29;
             // 
             // L_Poki
             // 
@@ -819,25 +851,6 @@
             TC_Editors.Size = new System.Drawing.Size(471, 331);
             TC_Editors.TabIndex = 1;
             // 
-            // L_HotelTickets
-            // 
-            L_HotelTickets.Location = new System.Drawing.Point(166, 273);
-            L_HotelTickets.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            L_HotelTickets.Name = "L_HotelTickets";
-            L_HotelTickets.Size = new System.Drawing.Size(98, 23);
-            L_HotelTickets.TabIndex = 30;
-            L_HotelTickets.Text = "Hotel Tickets:";
-            L_HotelTickets.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-            // 
-            // NUD_HotelTickets
-            // 
-            NUD_HotelTickets.Location = new System.Drawing.Point(271, 273);
-            NUD_HotelTickets.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            NUD_HotelTickets.Maximum = new decimal(new int[] { int.MaxValue, 0, 0, 0 });
-            NUD_HotelTickets.Name = "NUD_HotelTickets";
-            NUD_HotelTickets.Size = new System.Drawing.Size(117, 23);
-            NUD_HotelTickets.TabIndex = 29;
-            // 
             // Editor
             // 
             AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
@@ -861,6 +874,7 @@
             CM_EditMap.ResumeLayout(false);
             Tab_Players.ResumeLayout(false);
             Tab_Players.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)NUD_HotelTickets).EndInit();
             ((System.ComponentModel.ISupportInitialize)NUD_Poki).EndInit();
             ((System.ComponentModel.ISupportInitialize)NUD_TotalNookMiles).EndInit();
             ((System.ComponentModel.ISupportInitialize)NUD_StorageCount).EndInit();
@@ -872,7 +886,6 @@
             ((System.ComponentModel.ISupportInitialize)NUD_BankBells).EndInit();
             ((System.ComponentModel.ISupportInitialize)PB_Player).EndInit();
             TC_Editors.ResumeLayout(false);
-            ((System.ComponentModel.ISupportInitialize)NUD_HotelTickets).EndInit();
             ResumeLayout(false);
             PerformLayout();
 
@@ -953,6 +966,7 @@
         private System.Windows.Forms.NumericUpDown NUD_Poki;
         private System.Windows.Forms.Label L_HotelTickets;
         private System.Windows.Forms.NumericUpDown NUD_HotelTickets;
+        private System.Windows.Forms.Button B_EditCampsite;
     }
 }
 

--- a/NHSE.WinForms/Editor.cs
+++ b/NHSE.WinForms/Editor.cs
@@ -3,7 +3,6 @@ using NHSE.Injection;
 using NHSE.Sprites;
 using NHSE.WinForms.Properties;
 using System;
-using System.Diagnostics;
 using System.Drawing;
 using System.Drawing.Imaging;
 using System.IO;
@@ -73,7 +72,7 @@ public sealed partial class Editor : Form
         SaveAll();
         try
         {
-            SAV.Save((uint) DateTime.Now.Ticks);
+            SAV.Save((uint)DateTime.Now.Ticks);
         }
         catch (Exception ex)
         {
@@ -170,7 +169,7 @@ public sealed partial class Editor : Form
     {
         var p0 = SAV.Players[0].Personal;
         var villagers = SAV.Main.GetVillagers();
-        var v = new VillagerEditor(villagers, p0, SAV, true) {Dock = DockStyle.Fill};
+        var v = new VillagerEditor(villagers, p0, SAV, true) { Dock = DockStyle.Fill };
         Tab_Villagers.Controls.Add(v);
         return v;
     }
@@ -465,7 +464,7 @@ public sealed partial class Editor : Form
 
     private void B_EditPatternFlag_Click(object sender, EventArgs e)
     {
-        var patterns = new[] {SAV.Main.FlagMyDesign};
+        var patterns = new[] { SAV.Main.FlagMyDesign };
         using var editor = new PatternEditor(patterns);
         if (editor.ShowDialog() == DialogResult.OK)
             SAV.Main.FlagMyDesign = patterns[0];
@@ -489,6 +488,12 @@ public sealed partial class Editor : Form
         using var editor = new PlayerHouseEditor(houses, SAV.Players, SAV.Main, PlayerIndex);
         if (editor.ShowDialog() == DialogResult.OK)
             SAV.Main.SetPlayerHouses(houses);
+    }
+
+    private void B_EditCampsite_Click(object sender, EventArgs e)
+    {
+        using var editor = new CampsiteEditor(SAV);
+        editor.ShowDialog();
     }
 
     private void B_EditBulletin_Click(object sender, EventArgs e)
@@ -523,6 +528,6 @@ public sealed partial class Editor : Form
             SAV.Main.Visitor = boxed;
     }
 
-    private void NUD_PocketCount_ValueChanged(object sender, EventArgs e) => ((NumericUpDown) sender).BackColor = (uint) ((NumericUpDown) sender).Value > 20 ? Color.Red : NUD_BankBells.BackColor;
-    private void NUD_Wallet_ValueChanged(object sender, EventArgs e) => NUD_Wallet.BackColor = (ulong) NUD_Wallet.Value > 99_999 ? Color.Red : NUD_BankBells.BackColor;
+    private void NUD_PocketCount_ValueChanged(object sender, EventArgs e) => ((NumericUpDown)sender).BackColor = (uint)((NumericUpDown)sender).Value > 20 ? Color.Red : NUD_BankBells.BackColor;
+    private void NUD_Wallet_ValueChanged(object sender, EventArgs e) => NUD_Wallet.BackColor = (ulong)NUD_Wallet.Value > 99_999 ? Color.Red : NUD_BankBells.BackColor;
 }

--- a/NHSE.WinForms/Subforms/Map/CampsiteEditor.Designer.cs
+++ b/NHSE.WinForms/Subforms/Map/CampsiteEditor.Designer.cs
@@ -1,0 +1,275 @@
+﻿namespace NHSE.WinForms
+{
+    partial class CampsiteEditor
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            PB_Villager = new System.Windows.Forms.PictureBox();
+            L_ExternalName = new System.Windows.Forms.Label();
+            L_InternalName = new System.Windows.Forms.Label();
+            NUD_Variant = new System.Windows.Forms.NumericUpDown();
+            L_Variant = new System.Windows.Forms.Label();
+            NUD_Species = new System.Windows.Forms.NumericUpDown();
+            L_Species = new System.Windows.Forms.Label();
+            CB_CampsiteOccupied = new System.Windows.Forms.CheckBox();
+            L_Camper_ExternalName = new System.Windows.Forms.Label();
+            L_Camper_InternalName = new System.Windows.Forms.Label();
+            L_Camper_Edit = new System.Windows.Forms.Label();
+            L_CampsiteUnlockStatus = new System.Windows.Forms.Label();
+            B_Cancel = new System.Windows.Forms.Button();
+            B_Save = new System.Windows.Forms.Button();
+            CAL_CampTimestamp = new System.Windows.Forms.DateTimePicker();
+            L_CampDate = new System.Windows.Forms.Label();
+            ((System.ComponentModel.ISupportInitialize)PB_Villager).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)NUD_Variant).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)NUD_Species).BeginInit();
+            SuspendLayout();
+            // 
+            // PB_Villager
+            // 
+            PB_Villager.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            PB_Villager.Location = new System.Drawing.Point(17, 77);
+            PB_Villager.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            PB_Villager.Name = "PB_Villager";
+            PB_Villager.Size = new System.Drawing.Size(151, 150);
+            PB_Villager.SizeMode = System.Windows.Forms.PictureBoxSizeMode.Zoom;
+            PB_Villager.TabIndex = 59;
+            PB_Villager.TabStop = false;
+            // 
+            // L_ExternalName
+            // 
+            L_ExternalName.AutoSize = true;
+            L_ExternalName.Font = new System.Drawing.Font("Segoe UI", 9F);
+            L_ExternalName.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            L_ExternalName.Location = new System.Drawing.Point(98, 56);
+            L_ExternalName.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            L_ExternalName.Name = "L_ExternalName";
+            L_ExternalName.Size = new System.Drawing.Size(57, 15);
+            L_ExternalName.TabIndex = 65;
+            L_ExternalName.Text = "unknown";
+            L_ExternalName.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            // 
+            // L_InternalName
+            // 
+            L_InternalName.AutoSize = true;
+            L_InternalName.Font = new System.Drawing.Font("Courier New", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, 0);
+            L_InternalName.Location = new System.Drawing.Point(99, 235);
+            L_InternalName.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            L_InternalName.Name = "L_InternalName";
+            L_InternalName.Size = new System.Drawing.Size(56, 14);
+            L_InternalName.TabIndex = 64;
+            L_InternalName.Text = "unknown";
+            L_InternalName.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            // 
+            // NUD_Variant
+            // 
+            NUD_Variant.Location = new System.Drawing.Point(255, 104);
+            NUD_Variant.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            NUD_Variant.Maximum = new decimal(new int[] { 255, 0, 0, 0 });
+            NUD_Variant.Name = "NUD_Variant";
+            NUD_Variant.Size = new System.Drawing.Size(37, 23);
+            NUD_Variant.TabIndex = 63;
+            NUD_Variant.ValueChanged += ChangeVillager;
+            // 
+            // L_Variant
+            // 
+            L_Variant.ImageAlign = System.Drawing.ContentAlignment.MiddleRight;
+            L_Variant.Location = new System.Drawing.Point(191, 104);
+            L_Variant.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            L_Variant.Name = "L_Variant";
+            L_Variant.Size = new System.Drawing.Size(56, 23);
+            L_Variant.TabIndex = 62;
+            L_Variant.Text = "Variant:";
+            L_Variant.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+            // 
+            // NUD_Species
+            // 
+            NUD_Species.Location = new System.Drawing.Point(255, 79);
+            NUD_Species.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            NUD_Species.Maximum = new decimal(new int[] { 400, 0, 0, 0 });
+            NUD_Species.Name = "NUD_Species";
+            NUD_Species.Size = new System.Drawing.Size(37, 23);
+            NUD_Species.TabIndex = 61;
+            NUD_Species.ValueChanged += ChangeVillager;
+            // 
+            // L_Species
+            // 
+            L_Species.ImageAlign = System.Drawing.ContentAlignment.MiddleRight;
+            L_Species.Location = new System.Drawing.Point(191, 79);
+            L_Species.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            L_Species.Name = "L_Species";
+            L_Species.Size = new System.Drawing.Size(56, 23);
+            L_Species.TabIndex = 60;
+            L_Species.Text = "Species:";
+            L_Species.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+            // 
+            // CB_CampsiteOccupied
+            // 
+            CB_CampsiteOccupied.AutoSize = true;
+            CB_CampsiteOccupied.Location = new System.Drawing.Point(17, 31);
+            CB_CampsiteOccupied.Name = "CB_CampsiteOccupied";
+            CB_CampsiteOccupied.Size = new System.Drawing.Size(135, 19);
+            CB_CampsiteOccupied.TabIndex = 66;
+            CB_CampsiteOccupied.Text = "Campsite Has Visitor";
+            CB_CampsiteOccupied.UseVisualStyleBackColor = true;
+            // 
+            // L_Camper_ExternalName
+            // 
+            L_Camper_ExternalName.Location = new System.Drawing.Point(15, 52);
+            L_Camper_ExternalName.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            L_Camper_ExternalName.Name = "L_Camper_ExternalName";
+            L_Camper_ExternalName.Size = new System.Drawing.Size(80, 23);
+            L_Camper_ExternalName.TabIndex = 67;
+            L_Camper_ExternalName.Text = "Visitor Name:";
+            L_Camper_ExternalName.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            // 
+            // L_Camper_InternalName
+            // 
+            L_Camper_InternalName.Location = new System.Drawing.Point(15, 230);
+            L_Camper_InternalName.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            L_Camper_InternalName.Name = "L_Camper_InternalName";
+            L_Camper_InternalName.Size = new System.Drawing.Size(80, 23);
+            L_Camper_InternalName.TabIndex = 68;
+            L_Camper_InternalName.Text = "Villager Code:";
+            L_Camper_InternalName.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            // 
+            // L_Camper_Edit
+            // 
+            L_Camper_Edit.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            L_Camper_Edit.Location = new System.Drawing.Point(198, 54);
+            L_Camper_Edit.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            L_Camper_Edit.Name = "L_Camper_Edit";
+            L_Camper_Edit.Size = new System.Drawing.Size(68, 23);
+            L_Camper_Edit.TabIndex = 69;
+            L_Camper_Edit.Text = "Edit Visitor:";
+            L_Camper_Edit.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            // 
+            // L_CampsiteUnlockStatus
+            // 
+            L_CampsiteUnlockStatus.Font = new System.Drawing.Font("Segoe UI", 11.25F, System.Drawing.FontStyle.Italic, System.Drawing.GraphicsUnit.Point, 0);
+            L_CampsiteUnlockStatus.ForeColor = System.Drawing.Color.Red;
+            L_CampsiteUnlockStatus.Location = new System.Drawing.Point(61, 3);
+            L_CampsiteUnlockStatus.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            L_CampsiteUnlockStatus.Name = "L_CampsiteUnlockStatus";
+            L_CampsiteUnlockStatus.Size = new System.Drawing.Size(313, 23);
+            L_CampsiteUnlockStatus.TabIndex = 70;
+            L_CampsiteUnlockStatus.Text = "Campsite is not currently unlocked on this save.";
+            L_CampsiteUnlockStatus.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            // 
+            // B_Cancel
+            // 
+            B_Cancel.Anchor = System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right;
+            B_Cancel.Location = new System.Drawing.Point(215, 212);
+            B_Cancel.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            B_Cancel.Name = "B_Cancel";
+            B_Cancel.Size = new System.Drawing.Size(107, 46);
+            B_Cancel.TabIndex = 72;
+            B_Cancel.Text = "Cancel";
+            B_Cancel.UseVisualStyleBackColor = true;
+            B_Cancel.Click += B_Cancel_Click;
+            // 
+            // B_Save
+            // 
+            B_Save.Anchor = System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right;
+            B_Save.Location = new System.Drawing.Point(326, 212);
+            B_Save.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            B_Save.Name = "B_Save";
+            B_Save.Size = new System.Drawing.Size(107, 46);
+            B_Save.TabIndex = 71;
+            B_Save.Text = "Save";
+            B_Save.UseVisualStyleBackColor = true;
+            B_Save.Click += B_Save_Click;
+            // 
+            // CAL_CampTimestamp
+            // 
+            CAL_CampTimestamp.Location = new System.Drawing.Point(198, 165);
+            CAL_CampTimestamp.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            CAL_CampTimestamp.Name = "CAL_CampTimestamp";
+            CAL_CampTimestamp.Size = new System.Drawing.Size(233, 23);
+            CAL_CampTimestamp.TabIndex = 73;
+            // 
+            // L_CampDate
+            // 
+            L_CampDate.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            L_CampDate.Location = new System.Drawing.Point(198, 140);
+            L_CampDate.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            L_CampDate.Name = "L_CampDate";
+            L_CampDate.Size = new System.Drawing.Size(124, 22);
+            L_CampDate.TabIndex = 74;
+            L_CampDate.Text = "Set Camp Visit Date:";
+            L_CampDate.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            // 
+            // CampsiteEditor
+            // 
+            AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
+            AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            ClientSize = new System.Drawing.Size(441, 266);
+            Controls.Add(L_CampDate);
+            Controls.Add(CAL_CampTimestamp);
+            Controls.Add(B_Cancel);
+            Controls.Add(B_Save);
+            Controls.Add(L_CampsiteUnlockStatus);
+            Controls.Add(L_Camper_Edit);
+            Controls.Add(L_Camper_InternalName);
+            Controls.Add(L_Camper_ExternalName);
+            Controls.Add(CB_CampsiteOccupied);
+            Controls.Add(L_ExternalName);
+            Controls.Add(L_InternalName);
+            Controls.Add(NUD_Variant);
+            Controls.Add(L_Variant);
+            Controls.Add(NUD_Species);
+            Controls.Add(L_Species);
+            Controls.Add(PB_Villager);
+            Icon = Properties.Resources.icon;
+            Name = "CampsiteEditor";
+            Text = "Campsite Editor";
+            ((System.ComponentModel.ISupportInitialize)PB_Villager).EndInit();
+            ((System.ComponentModel.ISupportInitialize)NUD_Variant).EndInit();
+            ((System.ComponentModel.ISupportInitialize)NUD_Species).EndInit();
+            ResumeLayout(false);
+            PerformLayout();
+        }
+
+        #endregion
+        private System.Windows.Forms.PictureBox PB_Villager;
+        private System.Windows.Forms.Label L_ExternalName;
+        private System.Windows.Forms.Label L_InternalName;
+        private System.Windows.Forms.NumericUpDown NUD_Variant;
+        private System.Windows.Forms.Label L_Variant;
+        private System.Windows.Forms.NumericUpDown NUD_Species;
+        private System.Windows.Forms.Label L_Species;
+        private System.Windows.Forms.CheckBox CB_CampsiteOccupied;
+        private System.Windows.Forms.Label L_Camper_ExternalName;
+        private System.Windows.Forms.Label L_Camper_InternalName;
+        private System.Windows.Forms.Label L_Camper_Edit;
+        private System.Windows.Forms.Label L_CampsiteUnlockStatus;
+        private System.Windows.Forms.Button B_Cancel;
+        private System.Windows.Forms.Button B_Save;
+        private System.Windows.Forms.DateTimePicker CAL_CampTimestamp;
+        private System.Windows.Forms.Label L_CampDate;
+    }
+}

--- a/NHSE.WinForms/Subforms/Map/CampsiteEditor.cs
+++ b/NHSE.WinForms/Subforms/Map/CampsiteEditor.cs
@@ -1,0 +1,112 @@
+﻿using NHSE.Core;
+using NHSE.Sprites;
+using System;
+using System.Windows.Forms;
+
+namespace NHSE.WinForms;
+
+public partial class CampsiteEditor : Form
+{
+    private readonly HorizonSave SAV;
+    private bool CampsiteUnlocked;
+    private string GetUpdatedVillagerInternalName() => VillagerUtil.GetInternalVillagerName((VillagerSpecies)NUD_Species.Value, (int)NUD_Variant.Value);
+    private void ChangeVillager(object sender, EventArgs e) => ChangeVillager();
+    private void ChangeVillager()
+    {
+        var name = GetUpdatedVillagerInternalName();
+        L_InternalName.Text = name;
+        L_ExternalName.Text = GameInfo.Strings.GetVillager(name);
+        PB_Villager.Image = VillagerSprite.GetVillagerSprite(name);
+    }
+
+    public CampsiteEditor(HorizonSave sav)
+    {
+        InitializeComponent();
+        SAV = sav;
+
+        CheckCampsiteStatus();
+
+        LoadCampsiteVisitor();
+
+        DialogResult = DialogResult.Cancel;
+    }
+
+    private void CheckCampsiteStatus()
+    {
+        switch (SAV.Main.CampsiteStatus)
+        {
+            case 01:
+                CampsiteUnlocked = false;
+                CB_CampsiteOccupied.Checked = false;
+                break;
+            case 02:
+                CampsiteUnlocked = true;
+                CB_CampsiteOccupied.Checked = false;
+                break;
+            case 03:
+                CampsiteUnlocked = true;
+                CB_CampsiteOccupied.Checked = true;
+                break;
+        }
+
+        B_Save.Enabled = CampsiteUnlocked;
+        L_CampsiteUnlockStatus.Enabled = !CampsiteUnlocked;
+        if (CampsiteUnlocked)
+            L_CampsiteUnlockStatus.Text = null;
+        CB_CampsiteOccupied.Enabled = CampsiteUnlocked;
+        L_Camper_ExternalName.Enabled = CampsiteUnlocked;
+        L_ExternalName.Enabled = CampsiteUnlocked;
+        PB_Villager.Enabled = CampsiteUnlocked;
+        L_Camper_InternalName.Enabled = CampsiteUnlocked;
+        L_InternalName.Enabled = CampsiteUnlocked;
+        L_Camper_Edit.Enabled = CampsiteUnlocked;
+        L_Species.Enabled = CampsiteUnlocked;
+        NUD_Species.Enabled = CampsiteUnlocked;
+        L_Variant.Enabled = CampsiteUnlocked;
+        NUD_Variant.Enabled = CampsiteUnlocked;
+    }
+
+    private void LoadCampsiteVisitor()
+    {
+        NUD_Species.Value = SAV.Main.CampsiteVillagerSpeciesID;
+        NUD_Variant.Value = SAV.Main.CampsiteVillagerVariantID;
+        var name = GetUpdatedVillagerInternalName();
+        L_InternalName.Text = name;
+        L_ExternalName.Text = GameInfo.Strings.GetVillager(name);
+        PB_Villager.Image = VillagerSprite.GetVillagerSprite(name);
+        CAL_CampTimestamp.Value = DateTime.Now;
+    }
+
+    private void SaveCampsiteVisitor()
+    {
+        if (CampsiteUnlocked)
+        {
+            switch (CB_CampsiteOccupied.Checked)
+            {
+                case true:
+                    SAV.Main.CampsiteStatus = 0x03;
+                    SAV.Main.CampsiteVillagerVariantID = (byte)NUD_Variant.Value;
+                    SAV.Main.CampsiteVillagerSpeciesID = (byte)NUD_Species.Value;
+                    SAV.Main.CampTimestamp = CAL_CampTimestamp.Value;
+                    break;
+                case false:
+                    // The game performs a check and corrects status based on
+                    // villagerID or status - but let's clean up anyway.
+                    SAV.Main.CampsiteStatus = 0x02;
+                    SAV.Main.CampsiteVillagerVariantID = 0x00;
+                    SAV.Main.CampsiteVillagerSpeciesID = 0x23;
+                    break;
+            }
+        }
+    }
+
+    private void B_Save_Click(object sender, EventArgs e)
+    {
+        SaveCampsiteVisitor();
+
+        DialogResult = DialogResult.OK;
+        Close();
+    }
+
+    private void B_Cancel_Click(object sender, EventArgs e) => Close();
+}

--- a/NHSE.WinForms/Subforms/Map/CampsiteEditor.resx
+++ b/NHSE.WinForms/Subforms/Map/CampsiteEditor.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!--
+    Microsoft ResX Schema
+
+    Version 2.0
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
+    associated with the data types.
+
+    Example:
+
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+
+    There are any number of "resheader" rows that contain simple
+    name/value pairs.
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
+    mimetype set.
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
+    extensible. For a given mimetype the value must be set accordingly:
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
+    read any of the formats listed below.
+
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/NHSE.WinForms/Subforms/Player/MiscPlayerEditor.cs
+++ b/NHSE.WinForms/Subforms/Player/MiscPlayerEditor.cs
@@ -62,6 +62,30 @@ public partial class MiscPlayerEditor : Form
         Close();
     }
 
+    public void UpdateFruitFlags(MainSave sav)
+    {
+        var fruit = new byte[] { 00, 00, 00, 00, 00 };
+        switch (sav.SpecialtyFruit)
+        {
+            case 2213: // Apple
+                fruit[0] = 01;
+                break;
+            case 2287: // Cherry
+                fruit[4] = 01;
+                break;
+            case 2214: // Orange
+                fruit[1] = 01;
+                break;
+            case 2286: // Peach
+                fruit[3] = 01;
+                break;
+            case 2285: // Pear
+                fruit[2] = 01;
+                break;
+        }
+        sav.FruitFlags = fruit;
+    }
+
     private void SavePlayer()
     {
         var p = Player;
@@ -80,7 +104,8 @@ public partial class MiscPlayerEditor : Form
         pers.ProfileFruit = RIS_ProfileFruit.Value;
         sav.SpecialtyFruit = RIS_ProfileFruit.Value;
         sav.SisterFruit = RIS_SisterFruit.Value;
-        sav.UpdateFruitFlags();
+
+        UpdateFruitFlags(sav);
 
         sav.SpecialtyFlower = (IslandFlowers)CB_ProfileFlower.SelectedIndex;
         sav.SisterFlower = (IslandFlowers)CB_SisterFlower.SelectedIndex;


### PR DESCRIPTION
**Add:** Campsite Editor to Map tab.
* Allows users to set whether there is or is not a villager visiting the campsite, allows selecting that visitor and to edit the visit timestamp (defaults to current timestamp override so visitor is there on same day load).
* Back-tracked offsets from old Cylindircal Earth save schemas for old save revs.
* If campsite is not unlocked on the save, the UI is locked out with a message.

**Cleanup:** Moved UpdateFruitsFlag to misc editor class over save class because that was bad form. Oops.