### PR TITLE
[3.0.0] Add offset for the extra acres in front and behind of ItemLayer0 and ItemLayer1

### DIFF
--- a/NHSE.Core/Save/Files/MainSave.cs
+++ b/NHSE.Core/Save/Files/MainSave.cs
@@ -205,10 +205,10 @@ public sealed class MainSave : EncryptedFilePair
     private const int FieldItemLayerSize = MapGrid.MapTileCount32x32 * Item.SIZE;
     private const int FieldItemFlagSize = MapGrid.MapTileCount32x32 / 8; // bitflags
 
-    private int FieldItemLayer1 => Offsets.FieldItem;
-    private int FieldItemLayer2 => Offsets.FieldItem + FieldItemLayerSize;
-    public int FieldItemFlag1 => Offsets.FieldItem + (FieldItemLayerSize * 2);
-    public int FieldItemFlag2 => Offsets.FieldItem + (FieldItemLayerSize * 2) + FieldItemFlagSize;
+    private int FieldItemLayer1 => Offsets.FieldItem + Offsets.FieldItemLayerOffset;
+    private int FieldItemLayer2 => Offsets.FieldItem + FieldItemLayerSize + Offsets.FieldItemLayerOffset * (2 + 1);
+    public int FieldItemFlag1 => Offsets.FieldItem + ((FieldItemLayerSize + Offsets.FieldItemLayerOffset * 2) * 2);
+    public int FieldItemFlag2 => Offsets.FieldItem + ((FieldItemLayerSize + Offsets.FieldItemLayerOffset * 2) * 2) + FieldItemFlagSize;
 
     public Item[] GetFieldItemLayer1() => Item.GetArray(Data.Slice(FieldItemLayer1, FieldItemLayerSize));
     public void SetFieldItemLayer1(IReadOnlyList<Item> array) => Item.SetArray(array).CopyTo(Data[FieldItemLayer1..]);

--- a/NHSE.Core/Save/Offsets/MainSaveOffsets.cs
+++ b/NHSE.Core/Save/Offsets/MainSaveOffsets.cs
@@ -34,6 +34,9 @@ public abstract class MainSaveOffsets
     public abstract int EventFlagLand { get; }
     public abstract int FruitFlags { get; }
     public abstract int FieldItem { get; }
+
+    public virtual int FieldItemLayerOffset => 0;
+
     public abstract int LandMakingMap { get; }
     public abstract int OutsideField { get; }
     public abstract int MyDesignMap { get; }

--- a/NHSE.Core/Save/Offsets/MainSaveOffsets30.cs
+++ b/NHSE.Core/Save/Offsets/MainSaveOffsets30.cs
@@ -44,6 +44,9 @@ public class MainSaveOffsets30 : MainSaveOffsets
     // ItemSwitch1 1500 => 1B00
     // MainField 398 => 3AC
     public override int FieldItem => GSaveMainFieldStart + 0x00000;
+
+    public override int FieldItemLayerOffset => 8 * 32 * 192;
+
     public override int LandMakingMap => GSaveMainFieldStart + 0xdb600; // CHANGED*** all following are shifted.
     public override int MainFieldStructure => GSaveMainFieldStart + 0x100200;
     public override int OutsideField => GSaveMainFieldStart + 0x1005ac;


### PR DESCRIPTION
This is not very elegant, but it keeps intercompatibility for the ``.nhl`` file types.

Another thing still might be, that the ``FieldItemFlag``s have also changed in size; but they are padded in a different direction from what I tested so far; so that is still broken.