### PR TITLE
Add badge for DeepWiki to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,5 +14,6 @@ Edits savedata dumped from the Nintendo Switch.
 ## Other
 
 Refer to the [Wiki](https://github.com/kwsch/NHSE/wiki) for more information.
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/kwsch/NHSE)
 
 **We do not support or condone cheating at the expense of others.** Please be responsible!


### PR DESCRIPTION
This enables auto refresh by DeepWiki on a weekly basis. DeepWiki provides up-to-date documentation you can talk to, for any repo hosted publicly.