### PR TITLE
Fix: LoadDecrypted Villager[n]

### DIFF
--- a/NHSE.WinForms/Controls/VillagerEditor.cs
+++ b/NHSE.WinForms/Controls/VillagerEditor.cs
@@ -31,6 +31,8 @@ public partial class VillagerEditor : UserControl
 
     public void Save() => SaveVillager(VillagerIndex);
 
+    public void Reload() => LoadVillagers();
+
     private void LoadVillagers()
     {
         CB_Personality.Items.Clear();
@@ -38,6 +40,7 @@ public partial class VillagerEditor : UserControl
         CB_Personality.Items.AddRange(personalities);
 
         VillagerIndex = -1;
+        NUD_Villager.Value = 0;
         LoadVillager(0);
     }
 

--- a/NHSE.WinForms/Editor.cs
+++ b/NHSE.WinForms/Editor.cs
@@ -235,6 +235,7 @@ public sealed partial class Editor : Form
     {
         Villagers.Villagers = SAV.Main.GetVillagers();
         Villagers.Origin = SAV.Players[0].Personal;
+        Villagers.Reload();
         LoadPlayers();
     }
 


### PR DESCRIPTION
ReloadAll() wasn't loading the villager that was currently selected on load (or 0 if not in panel) leading to incorrect villager import.

Fix: Add public Reload() method to VillagerEditor to call LoadVillagers() and call it after Villagers and Origin are loaded. Reset Villager index NUD to 0 in LoadVillagers() so the slot is moved to 0 and then load occurs (so UI is refreshed and villager is loaded).