### PR TITLE
Fix: Map Design Import/Export

### DIFF
--- a/NHSE.Core/Resources/text/de/MessageStrings_de.txt
+++ b/NHSE.Core/Resources/text/de/MessageStrings_de.txt
@@ -1,6 +1,7 @@
 ﻿MsgBackupCreateLocation=NHSE can perform automatic backups if you create a folder with the name '{0}' in the same folder as the executable.
 MsgBackupCreateQuestion=Would you like NHSE to automatically keep a backup of your save data?
 MsgDataSizeMismatchImport=The size of the imported file (0x{0:X}) does not match the required size (0x{1:X}).
+MsgDataTrimmedWarning=It will be trimmed to fit.
 MsgDataSizeMismatchRAM=Read size (0x{0:X}) != Write size (0x{1:X}).
 MsgDataDidNotOriginateFromHost_0=Imported data did not originate from Villager0 ({0})'s data.
 MsgAskUpdateValues=Update values?

--- a/NHSE.Core/Resources/text/en/MessageStrings_en.txt
+++ b/NHSE.Core/Resources/text/en/MessageStrings_en.txt
@@ -1,6 +1,7 @@
 ﻿MsgBackupCreateLocation=NHSE can perform automatic backups if you create a folder with the name '{0}' in the same folder as the executable.
 MsgBackupCreateQuestion=Would you like NHSE to automatically keep a backup of your save data?
 MsgDataSizeMismatchImport=The size of the imported file (0x{0:X}) does not match the required size (0x{1:X}).
+MsgDataTrimmedWarning=It will be trimmed to fit.
 MsgDataSizeMismatchRAM=Read size (0x{0:X}) != Write size (0x{1:X}).
 MsgDataDidNotOriginateFromHost_0=Imported data did not originate from Villager0 ({0})'s data.
 MsgAskUpdateValues=Update values?

--- a/NHSE.Core/Resources/text/es/MessageStrings_es.txt
+++ b/NHSE.Core/Resources/text/es/MessageStrings_es.txt
@@ -1,6 +1,7 @@
 ﻿MsgBackupCreateLocation=NHSE puede crear un respaldos automáticos si crea una carpeta con el nombre '{0}' en la misma carpeta del ejecutable.
 MsgBackupCreateQuestion=¿Quisiera que NHSE cree automáticamente un respaldo de sus datos de guardado?
 MsgDataSizeMismatchImport=El tamaño del archivo importado (0x{0:X}) no coincide con el tamaño requerido (0x{1:X}).
+MsgDataTrimmedWarning=Se recortará para que encaje.
 MsgDataSizeMismatchRAM=Tamaño de lectura (0x{0:X}) != Tamaño de Escritura (0x{1:X}).
 MsgDataDidNotOriginateFromHost_0=Los datos importados no se originaron de los datos del Aldeano ({0}).
 MsgAskUpdateValues=¿Actualizar valores?

--- a/NHSE.Core/Resources/text/fr/MessageStrings_fr.txt
+++ b/NHSE.Core/Resources/text/fr/MessageStrings_fr.txt
@@ -1,6 +1,7 @@
 ﻿MsgBackupCreateLocation=NHSE peut effectuer des sauvegardes automatiques si vous créez un dossier portant le nom «{0}» dans le même dossier que l'exécutable.
 MsgBackupCreateQuestion=Souhaitez-vous que NHSE conserve automatiquement une sauvegarde de vos données de sauvegarde?
 MsgDataSizeMismatchImport=La taille du fichier importé (0x{0:X}) ne correspond pas à la taille requise (0x{1:X}).
+MsgDataTrimmedWarning=Il sera découpé aux dimensions voulues.
 MsgDataSizeMismatchRAM=Taille de lecture (0x{0:X})! = Taille d'écriture (0x{1:X}).
 MsgDataDidNotOriginateFromHost_0=Les données importées ne proviennent pas des données de Villager0({0}).
 MsgAskUpdateValues=Mettre à jour les valeurs?

--- a/NHSE.Core/Resources/text/it/MessageStrings_it.txt
+++ b/NHSE.Core/Resources/text/it/MessageStrings_it.txt
@@ -1,6 +1,7 @@
 ﻿MsgBackupCreateLocation=NHSE pu� fare backup automatici se crei una cartella chiamata '{0}' nella stessa cartella dell'eseguibile.
 MsgBackupCreateQuestion=Vuoi che NHSE faccia automaticamente un backup dei tuoi dati di salvataggio?
 MsgDataSizeMismatchImport=La dimensione del file importato (0x{0:X}) non corrisponde alla dimensione richiesta (0x{1:X}).
+MsgDataTrimmedWarning=Verrà ritagliato per adattarlo.
 MsgDataSizeMismatchRAM=Dimensione letta (0x{0:X}) != Dimensione da scrivere (0x{1:X}).
 MsgDataDidNotOriginateFromHost_0=I dati importati non derivano dai dati del Villager0 ({0}).
 MsgAskUpdateValues=Aggiornare i valori?

--- a/NHSE.Core/Resources/text/jp/MessageStrings_jp.txt
+++ b/NHSE.Core/Resources/text/jp/MessageStrings_jp.txt
@@ -1,6 +1,7 @@
 ﻿MsgBackupCreateLocation=実行可能ファイルと同じフォルダー内に '{0}' という名前のフォルダーを作成すると、NHSE は自動バックアップを実行できます。
 MsgBackupCreateQuestion=NHSE がセーブ データのバックアップを自動的に保存することを希望しますか?
 MsgDataSizeMismatchImport=インポートされたファイル (0x{0:X}) のサイズが必要なサイズ (0x{1:X}) と一致しません。
+MsgDataTrimmedWarning=フィットするようにトリミングされます。
 MsgDataSizeMismatchRAM=読み取りサイズ (0x{0:X}) は書き込みサイズ (0x{1:X}) と等しくありません。
 MsgDataDidNotOriginateFromHost_0=インポートされたデータは Villager0 ({0}) のデータからのものではありませんでした。
 MsgAskUpdateValues=値を更新しますか?

--- a/NHSE.Core/Resources/text/ko/MessageStrings_ko.txt
+++ b/NHSE.Core/Resources/text/ko/MessageStrings_ko.txt
@@ -1,6 +1,7 @@
 ﻿MsgBackupCreateLocation=실행 파일과 같은 폴더에 '{0}' 이름으로 폴더를 만들면 NHSE가 자동으로 백업을 수행합니다.
 MsgBackupCreateQuestion=NHSE가 세이브 데이터를 자동으로 백업하도록 설정하시겠습니까?
 MsgDataSizeMismatchImport=가져온 파일의 크기(0x{0:X})가 필요한 크기(0x{1:X})와 일치하지 않습니다.
+MsgDataTrimmedWarning=크기에 맞춰 다듬어질 것입니다.
 MsgDataSizeMismatchRAM=읽기 크기(0x{0:X})와 쓰기 크기(0x{1:X})가 다릅니다.
 MsgDataDidNotOriginateFromHost_0=가져온 데이터는 플레이어0({0})의 데이터가 아닙니다.
 MsgAskUpdateValues=값들을 업데이트하시겠습니까?

--- a/NHSE.Core/Resources/text/zhs/MessageStrings_zhs.txt
+++ b/NHSE.Core/Resources/text/zhs/MessageStrings_zhs.txt
@@ -1,6 +1,7 @@
 ﻿MsgBackupCreateLocation=如果您在本程序根目录创建 '{0}' 文件夹，NHSE可以帮您自动备份存档。
 MsgBackupCreateQuestion=您希望NHSE自动备份您的存档吗？
 MsgDataSizeMismatchImport=导入的文件尺寸(0x{0:X})和必要的文件尺寸(0x{1:X})不匹配。
+MsgDataTrimmedWarning=它会被修剪到合适的尺寸。
 MsgDataSizeMismatchRAM=读取大小 (0x{0:X}) != 写入大小 (0x{1:X})。
 MsgDataDidNotOriginateFromHost_0=导入的数据不是来自Villager0 ({0})的数据。
 MsgAskUpdateValues=更新数值？

--- a/NHSE.Core/Resources/text/zht/MessageStrings_zht.txt
+++ b/NHSE.Core/Resources/text/zht/MessageStrings_zht.txt
@@ -1,6 +1,7 @@
 ﻿MsgBackupCreateLocation=NHSE can perform automatic backups if you create a folder with the name '{0}' in the same folder as the executable.
 MsgBackupCreateQuestion=Would you like NHSE to automatically keep a backup of your save data?
 MsgDataSizeMismatchImport=The size of the imported file (0x{0:X}) does not match the required size (0x{1:X}).
+MsgDataTrimmedWarning=It will be trimmed to fit.
 MsgDataSizeMismatchRAM=Read size (0x{0:X}) != Write size (0x{1:X}).
 MsgDataDidNotOriginateFromHost_0=Imported data did not originate from Villager0 ({0})'s data.
 MsgAskUpdateValues=Update values?

--- a/NHSE.Core/Save/Files/MainSave.cs
+++ b/NHSE.Core/Save/Files/MainSave.cs
@@ -217,15 +217,15 @@ public sealed class MainSave : EncryptedFilePair
 
     public const ushort MapDesignNone = 0xF800;
 
-    public Memory<byte> MapDesignTileData => Raw.Slice(Offsets.MyDesignMap, (AcreWidth * LayerFieldItem.TilesPerAcreDim) * (AcreHeight * LayerFieldItem.TilesPerAcreDim) * sizeof(ushort));
-    public ushort[] GetMapDesignTiles() => MemoryMarshal.Cast<byte, ushort>(MapDesignTileData.Span).ToArray();
-    public void SetMapDesignTiles(ReadOnlySpan<ushort> value) => MemoryMarshal.Cast<ushort, byte>(value).CopyTo(MapDesignTileData.Span);
+    public Memory<byte> MapDesignTileData(int w, int h) => Raw.Slice(Offsets.MyDesignMap, (w * 16) * (h * 16) * sizeof(ushort));
+    public ushort[] GetMapDesignTiles(int w, int h) => MemoryMarshal.Cast<byte, ushort>(MapDesignTileData(w, h).Span).ToArray();
+    public void SetMapDesignTiles(ReadOnlySpan<ushort> value, int w, int h) => MemoryMarshal.Cast<ushort, byte>(value).CopyTo(MapDesignTileData(w, h).Span);
 
-    public void ClearDesignTiles()
+    public void ClearDesignTiles(int w, int h)
     {
-        var tiles = GetMapDesignTiles();
+        var tiles = GetMapDesignTiles(w, h);
         tiles.AsSpan().Fill(MapDesignNone);
-        SetMapDesignTiles(tiles);
+        SetMapDesignTiles(tiles, w, h);
     }
 
     private int FieldItemLayerSize => TotalFieldItemTileCount * Item.SIZE;

--- a/NHSE.Core/Util/ArrayUtil.cs
+++ b/NHSE.Core/Util/ArrayUtil.cs
@@ -28,4 +28,64 @@ public static class ArrayUtil
             ++count;
         }
     }
+
+    /// <summary>
+    /// Pads the specified byte array on the left side with the given padding bytes until it reaches the desired total length.
+    /// </summary>
+    /// <param name="original">The original byte array to pad.</param>
+    /// <param name="totalLength">The desired total length of the resulting array.</param>
+    /// <param name="paddingBytes">The byte pattern to use for padding. If multiple bytes are provided, they will repeat as needed.</param>
+    /// <returns>
+    /// A new byte array of <paramref name="totalLength"/> with padding on the left and the original content on the right.
+    /// If <paramref name="original"/> is already equal to or longer than <paramref name="totalLength"/>, returns the original array unchanged.
+    /// </returns>
+    public static byte[] PadLeft(byte[] original, int totalLength, byte[] paddingBytes)
+    {
+        int bytesNeeded = totalLength - original.Length;
+        if (bytesNeeded <= 0) return original;
+
+        byte[] paddedArray = new byte[totalLength];
+        int padBytesCount = paddingBytes.Length;
+
+        // Fill the left with padding bytes
+        for (int i = 0; i < bytesNeeded; i += padBytesCount)
+        {
+            for (int j = 0; j < padBytesCount && i + j < bytesNeeded; j++)
+                paddedArray[i + j] = paddingBytes[j];
+        }
+
+        // Copy the original array to the right of the padding
+        Buffer.BlockCopy(original, 0, paddedArray, bytesNeeded, original.Length);
+        return paddedArray;
+    }
+    /// <summary>
+    /// Pads the specified byte array on the right side with the given padding bytes until it reaches the desired total length.
+    /// </summary>
+    /// <param name="original">The original byte array to pad.</param>
+    /// <param name="totalLength">The desired total length of the resulting array.</param>
+    /// <param name="paddingBytes">The byte pattern to use for padding. If multiple bytes are provided, they will repeat as needed.</param>
+    /// <returns>
+    /// A new byte array of <paramref name="totalLength"/> with the original content on the left and padding on the right.
+    /// If <paramref name="original"/> is already equal to or longer than <paramref name="totalLength"/>, returns the original array unchanged.
+    /// </returns>
+    public static byte[] PadRight(byte[] original, int totalLength, byte[] paddingBytes)
+    {
+        int bytesNeeded = totalLength - original.Length;
+        if (bytesNeeded <= 0) return original;
+
+        byte[] paddedArray = new byte[totalLength];
+        // Copy the original array to the left
+        Buffer.BlockCopy(original, 0, paddedArray, 0, original.Length);
+
+        int padBytesCount = paddingBytes.Length;
+
+        // Fill the right with padding bytes
+        for (int i = 0; i < bytesNeeded; i += padBytesCount)
+        {
+            for (int j = 0; j < padBytesCount && original.Length + i + j < totalLength; j++)
+                paddedArray[original.Length + i + j] = paddingBytes[j];
+        }
+
+        return paddedArray;
+    }
 }

--- a/NHSE.WinForms/Subforms/Map/FieldItemEditor.resx
+++ b/NHSE.WinForms/Subforms/Map/FieldItemEditor.resx
@@ -129,11 +129,11 @@
   <metadata name="CM_Remove.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>465, 17</value>
   </metadata>
-  <metadata name="CM_DLBuilding.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>930, 17</value>
-  </metadata>
   <metadata name="CM_DLField.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>620, 17</value>
+  </metadata>
+  <metadata name="CM_DLBuilding.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>930, 17</value>
   </metadata>
   <metadata name="CM_DLMapAcres.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 56</value>

--- a/NHSE.WinForms/Util/MessageStrings.cs
+++ b/NHSE.WinForms/Util/MessageStrings.cs
@@ -7,6 +7,7 @@ public static class MessageStrings
     public static string MsgBackupCreateQuestion { get; set; } = "Would you NHSE to automatically keep a backup of your save data?";
 
     public static string MsgDataSizeMismatchImport { get; set; } = "The size of the imported file (0x{0:X}) does not match the required size (0x{1:X}).";
+    public static string MsgDataTrimmedWarning { get; set; } = "It will be trimmed to fit.";
     public static string MsgDataSizeMismatchRAM { get; set; } = "Read size (0x{0:X}) != Write size (0x{1:X}).";
     public static string MsgDataDidNotOriginateFromHost_0 { get; set; } = "Imported data did not originate from Villager0 ({0})'s data.";
 


### PR DESCRIPTION
Previous fix for bad map design imports had an incorrect range and no way to manage v2.0.8- and v3.0.0+ dumps.

Import/Export for map design patterns now supports both map sizes (old and new).
It will accept 2.0.8 dumps and pad them to work on 3.0.0 as well as trim previously mangled ones, or 3.0.0 dumps down to fit on 2.0.8 saves.

Byte padding methods added to ArrayUtil for this padding and for future map flag import padding fixes.